### PR TITLE
Serve "scene.html" as default

### DIFF
--- a/src/utils/start-server.ts
+++ b/src/utils/start-server.ts
@@ -1,13 +1,18 @@
 import chalk from 'chalk';
+import isDev from './is-dev';
 const budo = require('budo');
 
 export default function (args: any, vorpal: any, callback: () => void): void {
   vorpal.log(chalk.blue('Parcel server is starting...\n'));
-
-  budo('./', {
+  const baseDir = isDev ? './tmp/dcl-app' : '.'
+  budo('.', {
     host: '0.0.0.0',
-    live: true,
+    live: baseDir + '**/*',
+    dir: baseDir,
     port: 2044,
-    stream: process.stdout
+    stream: process.stdout,
+    staticOptions: {
+      index: 'scene.html'
+    }
   });
 }


### PR DESCRIPTION
Serve `scene.html` as index page, use `./tmp/dcl-app` as baseDir for development

To the reviewer:

1. to test this checkout `feature/serve-scene`
2. do `npm run build && npm start`
3. when inside the `dcl` console do `init` (enter enter enter enter)
4. then `start`. 

You should be able to open `http://localhost:2044` and get the preview of the scene served.

Issue: #14 