### PR TITLE
[fix] `dcl serve`

### DIFF
--- a/src/utils/serve.ts
+++ b/src/utils/serve.ts
@@ -1,10 +1,20 @@
 import chalk from 'chalk';
 import { isDev } from '../utils/is-dev';
+import * as fs from 'fs';
 const liveServer = require('live-server');
 
 export function serve(vorpal: any, args: any, ): void {
   vorpal.log(chalk.blue('Parcel server is starting...\n'));
-  const dir = isDev ? './tmp/dcl-app' : '.';
+  let dir = '.'
+  if (isDev) {
+    try {
+      dir = `./tmp/${fs.readdirSync('./tmp')[0]}`
+    } catch (e) {
+      // this happens only in dev mode when you run `dcl serve` without running `dcl init` first
+      console.error('Project not initialized!') 
+      return
+    }
+  }
   liveServer.start({
     port: 2044,
     host: '0.0.0.0',


### PR DESCRIPTION
Fixes #36 and also fails gracefully if running `dcl serve` without running `dcl init` first.

To  review:

1. checkout branch `fix/serve`
2. `npm run build`
3. `npm start -- init`
4. `npm start -- serve`
5. It should open the browser and serve the scene, on the console it should say `Serving ./tmp/[project-name] at [host]:[port]`