### PR TITLE
use `dcl init` and other commands from working dir, refactor dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CLI tool for parcel management.
 * [x] Quickly create new projects
 * [x] Uploading scenes to IPFS
 * [x] Hot reloading
-* [ ] Linking Ethereum to the scene
+* [x] Linking Ethereum to the scene
 * [ ] Editor modifying local files and “uploading” to the directory
 * [ ] Optimizing objects, textures
 * [ ] Warnings and linting of scenes
@@ -23,7 +23,7 @@ $ npm install -g dcl-cli
 
 ## Usage
 
-- Initialize new Decentraland project:
+- Initialize new Decentraland project **from working directory**:
 
 ```bash
 $ dcl init
@@ -48,6 +48,12 @@ $ dcl upload
 
 ```bash
 $ dcl link
+```
+
+- Upload scene to IPFS, update IPNS and link Ethereum to the current scene in one go:
+
+```bash
+$ dcl push
 ```
 
 ## Building

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -80,17 +80,8 @@ export function init(vorpal: any) {
         return;
       }
 
-      const parsedProjectName = sceneMeta.display.title.toLowerCase().replace(/\s/g, '-');
-      let projectDir;
-      if (args.options.path && args.options.path === '.') {
-        projectDir = args.options.path;
-      } else {
-        projectDir = args.options.path
-          ? `${args.options.path}/${parsedProjectName}`
-          : parsedProjectName;
-      }
-
-      const dirName = isDev ? `tmp/${projectDir}` : `${projectDir}`;
+      const path = args.options.path ? args.options.path : '.';
+      const dirName = isDev ? './tmp/' : path;
 
       fs.copySync(
         `${cliPath}/dist/linker-app`,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -12,46 +12,19 @@ export function update(vorpal: any) {
     .command('update')
     .description('Update Ethereum linker tool.')
     .action(wrapAsync(async function (args: any, callback: () => void) {
-      let projectName = project.getDefaultName();
+      const path = isDev ? './tmp/' : '.';
 
-      if (isDev) {
-        const res = await inquirer.prompt({
-          type: 'input',
-          name: 'projectName',
-          default: projectName,
-          message:
-            '(Development-mode) Project name (in \'tmp/\' folder) you want to update: '
-        });
-
-        projectName = res.projectName;
-
-        const isDclProject = await fs.pathExists(`tmp/${projectName}/scene.json`);
-        if (!isDclProject) {
-          vorpal.log(
-            `Seems like that is not a Decentraland project! ${chalk.grey(
-              '(\'scene.json\' not found.)'
-            )}`
-          );
-          callback();
-        }
-
-        await fs.copy(
-          `${cliPath}/dist/linker-app`,
-          `tmp/${projectName}/.decentraland/linker-app`
+      const isDclProject = await fs.pathExists(`${path}/scene.json`);
+      if (!isDclProject) {
+        vorpal.log(
+          `Seems like this is not a Decentraland project! ${chalk.grey(
+            '(\'scene.json\' not found.)'
+          )}`
         );
-      } else {
-        const isDclProject = await fs.pathExists('./scene.json');
-        if (!isDclProject) {
-          vorpal.log(
-            `Seems like this is not a Decentraland project! ${chalk.grey(
-              '(\'scene.json\' not found.)'
-            )}`
-          );
-          callback();
-        }
-
-        await fs.copy(`${cliPath}/dist/linker-app`, './.decentraland/linker-app');
-        vorpal.log('CLI linking app updated!');
+        callback();
       }
+
+      await fs.copy(`${cliPath}/dist/linker-app`, `${path}/.decentraland/linker-app`);
+      vorpal.log('CLI linking app updated!');
     }));
 }

--- a/src/utils/linker.ts
+++ b/src/utils/linker.ts
@@ -8,16 +8,9 @@ import { isDev } from './is-dev';
 import { prompt } from './prompt';
 
 export async function linker(vorpal: any, args: any, callback: () => void) {
-  let projectName = project.getDefaultName();
+  const path = isDev ? './tmp/' : '.';
 
-  if (isDev) {
-    projectName = await prompt('(Development-mode) Project name you want to upload: ', projectName);
-  }
-
-  const root = isDev ? `tmp/${projectName}` : '.';
-
-  const isDclProject = await fs.pathExists(`${root}/scene.json`);
-
+  const isDclProject = await fs.pathExists(`${path}/scene.json`);
   if (!isDclProject) {
     vorpal.log(`Seems like this is not a Decentraland project! ${chalk.grey('(\'scene.json\' not found.)')}`);
     callback();
@@ -25,7 +18,7 @@ export async function linker(vorpal: any, args: any, callback: () => void) {
   }
 
   const hasLinker = await fs.pathExists(
-    `${root}/.decentraland/linker-app/linker/index.html`
+    `${path}/.decentraland/linker-app/linker/index.html`
   );
 
   if (!hasLinker) {
@@ -39,14 +32,14 @@ export async function linker(vorpal: any, args: any, callback: () => void) {
   const app = new Koa();
   const router = new Router();
 
-  app.use(serve(`${root}/.decentraland/linker-app`));
+  app.use(serve(`${path}/.decentraland/linker-app`));
 
   router.get('/api/get-scene-data', async (ctx) => {
-    ctx.body = await fs.readJson(`${root}/scene.json`);
+    ctx.body = await fs.readJson(`${path}/scene.json`);
   });
 
   router.get('/api/get-ipns-hash', async (ctx) => {
-    const ipnsHash = await fs.readFile(`${root}/.decentraland/ipns`, 'utf8');
+    const ipnsHash = await fs.readFile(`${path}/.decentraland/ipns`, 'utf8');
     ctx.body = JSON.stringify(ipnsHash);
   });
 

--- a/src/utils/serve.ts
+++ b/src/utils/serve.ts
@@ -4,11 +4,11 @@ const liveServer = require('live-server');
 
 export function serve(vorpal: any, args: any, ): void {
   vorpal.log(chalk.blue('Parcel server is starting...\n'));
-  const dir = isDev ? './tmp/dcl-app' : '.';
+
   liveServer.start({
     port: 2044,
     host: '0.0.0.0',
-    root: dir,
+    root: isDev ? './tmp/' : '.',
     open: true,
     ignore: '.decentraland',
     file: 'scene.html',

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -11,15 +11,9 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
   // You need to have ipfs daemon running!
   const ipfsApi = ipfsAPI('localhost', args.options.port || '5001');
 
-  let projectName = project.getDefaultName();
+  const path = isDev ? './tmp/' : '.';
 
-  if (isDev) {
-    projectName = await prompt('(Development-mode) Project name you want to upload: ', projectName);
-  }
-
-  const root = isDev ? `tmp/${projectName}` : '.';
-
-  const isDclProject = await fs.pathExists(`${root}/scene.json`);
+  const isDclProject = await fs.pathExists(`${path}/scene.json`);
   if (!isDclProject) {
     vorpal.log(
       `Seems like this is not a Decentraland project! ${chalk.grey(
@@ -32,21 +26,21 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
   const data = [
     {
       path: `tmp/scene.html`,
-      content: new Buffer(fs.readFileSync(`${root}/scene.html`))
+      content: new Buffer(fs.readFileSync(`${path}/scene.html`))
     },
     {
       path: `tmp/scene.json`,
-      content: new Buffer(fs.readFileSync(`${root}/scene.json`))
+      content: new Buffer(fs.readFileSync(`${path}/scene.json`))
     }
   ];
 
   // Go through project folders and add files if available
   ['audio', 'models', 'textures'].forEach(async (type: string) => {
-    const folder = await fs.readdir(`${root}/${type}`);
+    const folder = await fs.readdir(`${path}/${type}`);
     folder.forEach((name: string) =>
       data.push({
         path: `tmp/${type}/${name}`,
-        content: new Buffer(fs.readFileSync(`${root}/${type}/${name}`))
+        content: new Buffer(fs.readFileSync(`${path}/${type}/${name}`))
       })
     );
   });
@@ -82,7 +76,7 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
     ipnsHash = publishResult.name || publishResult.Name;
     vorpal.log(`IPNS Link: /ipns/${publishResult.name || publishResult.Name}`);
 
-    await fs.outputFile(`${root}/.decentraland/ipns`, ipnsHash);
+    await fs.outputFile(`${path}/.decentraland/ipns`, ipnsHash);
   } catch (err) {
     vorpal.log(err.message);
   }


### PR DESCRIPTION
Fix #39 #36
`dcl init` now creates DCL project **inside of working directory**!
1. `npm run build`
2. `npm start -- init`
3. every other command should now look for `tmp` directory and don't ask for any additional questions in console.

After `npm link`:
1. `mkdir project-name`
2. `cd project-name`
3. `dcl init`
4. every other command should now look for `'.'` directory.