### PR TITLE
fix client url, live-reload, and added watch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ $ dcl push
 `dcl` command should now be available.
 
 For CLI tool development, run `npm start` in your terminal.
+
+You can run CLI commands in development mode like this: `npm start -- init`
+
+You can do incremental compilations by running `npm run watch`, but you will need to run `npm run build` at least once before to build the `linker-app`, and if you make changes to the linker you will need to re-run `npm run build`.

--- a/live-reload.js
+++ b/live-reload.js
@@ -1,0 +1,35 @@
+if ("WebSocket" in window) {
+  (function() {
+    function refreshCSS() {
+      var sheets = [].slice.call(document.getElementsByTagName("link"));
+      var head = document.getElementsByTagName("head")[0];
+      for (var i = 0; i < sheets.length; ++i) {
+        var elem = sheets[i];
+        head.removeChild(elem);
+        var rel = elem.rel;
+        if (
+          (elem.href && typeof rel != "string") ||
+          rel.length == 0 ||
+          rel.toLowerCase() == "stylesheet"
+        ) {
+          var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, "");
+          elem.href =
+            url +
+            (url.indexOf("?") >= 0 ? "&" : "?") +
+            "_cacheOverride=" +
+            new Date().valueOf();
+        }
+        head.appendChild(elem);
+      }
+    }
+    var protocol = window.location.protocol === "http:" ? "ws://" : "wss://";
+    var address =
+      protocol + window.location.host + window.location.pathname + "/ws";
+    var socket = new WebSocket(address);
+    socket.onmessage = function(msg) {
+      if (msg.data == "reload") window.location.reload();
+      else if (msg.data == "refreshcss") refreshCSS();
+    };
+    console.log("Live reload enabled.");
+  })();
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "start": "./dev.js",
+    "watch": "tsc --watch",
     "build": "npm run clean && tsc && npm run linker:build",
     "clean": "rimraf dist && rimraf tmp",
     "linker:dev": "next",
@@ -37,6 +38,7 @@
   "dependencies": {
     "@types/fs-extra": "^5.0.0",
     "@types/next": "^2.4.7",
+    "axios": "^0.17.1",
     "babel-polyfill": "^6.26.0",
     "chalk": "^2.3.0",
     "decentraland-commons": "git+https://github.com/decentraland/commons.git#release",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -87,6 +87,10 @@ export function init(vorpal: any) {
         `${cliPath}/dist/linker-app`,
         `${dirName}/.decentraland/linker-app`
       );
+      fs.copySync(
+        `${cliPath}/live-reload.js`,
+        `${dirName}/.decentraland/live-reload.js`
+      );
       // Project folders
       fs.ensureDirSync(`${dirName}/audio`);
       fs.ensureDirSync(`${dirName}/models`);
@@ -95,7 +99,7 @@ export function init(vorpal: any) {
         `${dirName}/scene.json`,
         JSON.stringify(sceneMeta, null, 2)
       );
-      this.log(`\nNew project created in '${dirName}' directory.\n`);
+      this.log(`\nNew project created in '${dirName}' directory.\n`)
 
       const createScene = async (
         pathToProject: string,
@@ -116,7 +120,7 @@ export function init(vorpal: any) {
       };
 
       if (args.options.boilerplate) {
-        const html = generateHtml({ withSampleScene: true });
+        const html = await generateHtml({ withSampleScene: true })
         await createScene(dirName, html, true);
       } else {
         const results = await inquirer.prompt({
@@ -129,10 +133,10 @@ export function init(vorpal: any) {
         });
 
         if (results.sampleScene) {
-          const html = generateHtml({ withSampleScene: true });
+          const html = await generateHtml({ withSampleScene: true })
           await createScene(dirName, html, true);
         } else {
-          const html = generateHtml({ withSampleScene: false });
+          const html = await generateHtml({ withSampleScene: false })
           await createScene(dirName, html, false);
         }
       }

--- a/src/utils/generate-html.ts
+++ b/src/utils/generate-html.ts
@@ -1,26 +1,31 @@
+import axios from 'axios'
+
 interface GeneratorSettings {
   withSampleScene?: boolean;
 }
 
-export function generateHtml({ withSampleScene = false }: GeneratorSettings): string {
+export async function generateHtml({ withSampleScene = false }: GeneratorSettings): string {
   const sampleScene = `<a-box position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
       <a-sphere position="0 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>
       <a-cylinder position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
       <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
       <a-sky color="#ECECEC"></a-sky>`;
 
+  const { data } = await axios.get('https://client.decentraland.today/assets.json')
+
   const html = `<!DOCTYPE html>
 <html>
   <head>
     <title>Blank Decentraland scene</title>
+    <script src=".decentraland/live-reload.js"></script>
+    <script charset="utf-8" src="https://client.decentraland.today${data.preview.js}"></script>
   </head>
   <body>
     <a-scene>
       ${withSampleScene ? sampleScene : '<!-- Your scene code -->'}
     </a-scene>
   </body>
-  <script src="https://client.decentraland.today/preview.js" />
-</html>`;
+</html>`
 
-  return html;
+  return html
 }

--- a/src/utils/generate-html.ts
+++ b/src/utils/generate-html.ts
@@ -4,7 +4,7 @@ interface GeneratorSettings {
   withSampleScene?: boolean;
 }
 
-export async function generateHtml({ withSampleScene = false }: GeneratorSettings): string {
+export async function generateHtml({ withSampleScene = false }: GeneratorSettings): Promise<string> {
   const sampleScene = `<a-box position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
       <a-sphere position="0 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>
       <a-cylinder position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>


### PR DESCRIPTION
Fixes #35 and #42, I also added a `watch` script that we can run after the first `npm run build` to do incremental compilations (it doesn't rebuild the linker tho, for that one we need to re-run `npm run build` after we make changes to it).