### PR TITLE
[fix] IPNS links

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dcl": "./bin/dcl"
   },
   "dependencies": {
+    "@types/uuid": "^3.4.3",
     "axios": "^0.17.1",
     "babel-polyfill": "^6.26.0",
     "chalk": "^2.3.0",
@@ -55,6 +56,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "root-check": "^1.0.0",
+    "uuid": "^3.2.1",
     "vorpal": "^1.12.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "CLI tool for parcel management.",
   "main": "./dist/index.js",
   "scripts": {

--- a/pages/linker.js
+++ b/pages/linker.js
@@ -27,10 +27,10 @@ async function getSceneMetadata() {
   return await res.json();
 }
 
-async function getIpnsHash() {
-  const res = await fetch('/api/get-ipns-hash');
-  const ipnsHash = await res.json();
-  return ipnsHash;
+async function getIPFSKey() {
+  const res = await fetch('/api/get-ipfs-key');
+  const ipfsKey = await res.json();
+  return ipfsKey;
 }
 
 async function closeServer(ok, message) {
@@ -83,8 +83,8 @@ export default class Page extends React.Component {
       }
 
       try {
-        const ipnsHash = await getIpnsHash();
-        this.setState({ ipnsHash });
+        const ipfsKey = await getIPFSKey();
+        this.setState({ ipfsKey });
       } catch(err) {
         this.setState({
           error: `There was a problem getting IPNS hash of your scene.\nTry to re-upload with dcl upload.`
@@ -124,7 +124,7 @@ export default class Page extends React.Component {
         version: 0,
         name,
         description,
-        ipns: `ipns:${this.state.ipnsHash}`
+        ipns: `ipns:${this.state.ipfsKey}`
       })
       try {
         console.log('update land data', coordinates, data)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,7 @@ import { cliPath }from '../utils/cli-path';
 import { generateHtml } from '../utils/generate-html';
 import { wrapAsync } from '../utils/wrap-async';
 import { getRoot } from '../utils/get-root';
+import * as uuid from 'uuid';
 
 export function init(vorpal: any) {
   vorpal
@@ -97,6 +98,13 @@ export function init(vorpal: any) {
       fs.copySync(
         `${cliPath}/static/preview.js`,
         `${dirName}/.decentraland/preview.js`
+      );
+      fs.outputFileSync(
+        `${dirName}/.decentraland/project.json`,
+        JSON.stringify({
+          id: uuid.v4(),
+          ipfsKey: null
+        }, null, 2)
       );
       // Project folders
       fs.ensureDirSync(`${dirName}/audio`);

--- a/src/utils/linker.ts
+++ b/src/utils/linker.ts
@@ -43,9 +43,15 @@ export async function linker(vorpal: any, args: any, callback: () => void) {
     ctx.body = await fs.readJson(`${path}/scene.json`);
   });
 
-  router.get('/api/get-ipns-hash', async (ctx) => {
-    const ipnsHash = await fs.readFile(`${path}/.decentraland/ipns`, 'utf8');
-    ctx.body = JSON.stringify(ipnsHash);
+  router.get('/api/get-ipfs-key', async (ctx) => {
+    let project
+    try {
+      project = JSON.parse(fs.readFileSync(`${path}/.decentraland/project.json`, 'utf-8'))
+    } catch (error) {
+      vorpal.error('Could not find `.decentraland/project.json`')
+      process.exit(1)
+    }
+    ctx.body = JSON.stringify(project.ipfsKey);
   });
 
   router.get('/api/contract-address', async (ctx) => {

--- a/src/utils/linker.ts
+++ b/src/utils/linker.ts
@@ -48,7 +48,7 @@ export async function linker(vorpal: any, args: any, callback: () => void) {
     try {
       project = JSON.parse(fs.readFileSync(`${path}/.decentraland/project.json`, 'utf-8'))
     } catch (error) {
-      vorpal.error('Could not find `.decentraland/project.json`')
+      vorpal.log(chalk.red('Could not find `.decentraland/project.json`'))
       process.exit(1)
     }
     ctx.body = JSON.stringify(project.ipfsKey);

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -21,6 +21,7 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
       )}`
     );
     callback();
+    return
   }
 
   const data = [
@@ -53,6 +54,23 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
     // vorpal.log(`${progCount}, ${accumProgress}`)
   };
 
+  // generate an ipfs private key for this project if it doesn't have any yet
+  let project
+  try {
+    project = JSON.parse(fs.readFileSync(`${path}/.decentraland/project.json`, 'utf-8'))
+  } catch (error) {
+    vorpal.error('Could not find `.decentraland/project.json`')
+    process.exit(1)
+  }
+
+  if (project.ipfsKey == null) {
+    vorpal.log('Generating IPFS key...')
+    const { id } = await ipfsApi.key.gen(project.id, { type: 'rsa', size: 2048 })
+    project.ipfsKey = id
+    console.log('New IPFS key', project.ipfsKey)
+    fs.outputFileSync(`${path}/.decentraland/project.json`, JSON.stringify(project, null, 2))
+  }
+
   let ipfsHash;
   let ipnsHash;
 
@@ -70,19 +88,14 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
     // TODO: pinning --- ipfs.pin.add(hash, function (err) {})
 
     vorpal.log('Updating IPNS reference to folder hash... (this might take a while)');
-
-    const publishResult = await ipfsApi.name.publish(ipfsHash);
-
-    ipnsHash = publishResult.name || publishResult.Name;
-    vorpal.log(`IPNS Link: /ipns/${publishResult.name || publishResult.Name}`);
-
-    await fs.outputFile(`${path}/.decentraland/ipns`, ipnsHash);
+    const { name } = await ipfsApi.name.publish(ipfsHash, { key: project.id });
+    vorpal.log(`IPNS Link: /ipns/${name}`);
   } catch (err) {
     vorpal.log(err.message);
     if (err.message.indexOf('ECONNREFUSED') != -1) {
       vorpal.log(chalk.red('\nMake sure you have the IPFS daemon running (https://ipfs.io/docs/install/).'));
     }
-    process.exit(0)
+    process.exit(1)
   }
 
   return ipnsHash;

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -67,7 +67,7 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
     vorpal.log('Generating IPFS key...')
     const { id } = await ipfsApi.key.gen(project.id, { type: 'rsa', size: 2048 })
     project.ipfsKey = id
-    console.log('New IPFS key', project.ipfsKey)
+    vorpal.log(`New IPFS key: ${project.ipfsKey}`)
     fs.outputFileSync(`${path}/.decentraland/project.json`, JSON.stringify(project, null, 2))
   }
 

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -59,7 +59,7 @@ export async function uploader(vorpal: any, args: any, callback: () => void) {
   try {
     project = JSON.parse(fs.readFileSync(`${path}/.decentraland/project.json`, 'utf-8'))
   } catch (error) {
-    vorpal.error('Could not find `.decentraland/project.json`')
+    vorpal.log(chalk.red('Could not find `.decentraland/project.json`'))
     process.exit(1)
   }
 


### PR DESCRIPTION
This PR solves the bug that is preventing two projects to have different IPNS links. The problem was that the IPFS key used to generate the IPNS hash was the Peer ID (one per IPFS node), so all the projects using the same IPFS daemon would end up having the same IPNS link.

I added a `project.json` in `.decentraland` that cointains a unique id for the project, and the IPFS key's **name** (note that this is only a reference to the private key, the actual private key is stored in the ipfs node. This hash is actually what ends up being the ipns hash in the end, so it can be public).

I tried to add `export` / `import` commands to be able to get the `.pem` and load it again (ie. from a different computer) but I ran into some weird IPFS exceptions, I'll leave that one for a second PR.

Currently the work around for the situation above would be to generate a new IPFS key and re-link.

**To the reviewer**

I already published `v0.2.9` under the `next` tag, so to test this you can just `npm i -g decentraland@next`, then create two separate projects, and push each of them. You should see they generate different IPNS hashes on the console logs.



