### PR TITLE
chore: upgrades and windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ CLI tool for parcel management.
 
 ## Requirements
 
-- NodeJS v8 and above
+- [NodeJS v8 and above](https://github.com/decentraland/cli#nodejs-installation)
 - [Python 2.7](https://www.python.org/downloads/)
 - [IPFS](https://dist.ipfs.io/#go-ipfs)
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,31 @@ CLI tool for parcel management.
 * [ ] Test framework for scripting
 * [ ] Snapshots of the scene
 
-## Installation
+## Requirements
+
+- NodeJS v8 and above
+- [Python 2.7](https://www.python.org/downloads/)
+- [IPFS](https://dist.ipfs.io/#go-ipfs)
+
+## NodeJS Installation
+
+### MacOS/Linux:
+
+You need to have NodeJS (version 8.*.* and above) installed on your system to use the CLI. You can use official NodeJS installer, but on MacOS/Linux we recommend to use [NVM](https://github.com/creationix/nvm) for managing your NodeJS installation. Please follow the installation instructions.
+
+### Windows:
+
+We recommend using official NodeJS installer - download the latest LTS version [here](https://nodejs.org/en/download/) (we only support version 8.*.* and above).
+
+### CLI installation
+
+If you have NodeJS installed, run this command from terminal:
 
 ```bash
 $ npm install -g decentraland
 ```
+
+This should install CLI tool and make it available globally. Please proceed to [usage](https://github.com/decentraland/cli#usage) documentation.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,29 @@ $ dcl link
 $ dcl push
 ```
 
+## Updating
+
+If you encounter a message `Ethereum linker app is outdated! Please run dcl upgrade!`, you need to update the Ethereum linker inside your Decentraland project:
+
+1. `cd your-dcl-project`
+2. `dcl upgrade`
+
+To update the CLI tool:
+
+```bash
+$ npm update -g decentraland
+```
+
 ## Building
 
 1. Clone the repo: `git clone https://github.com/decentraland/cli.git`
-2. Go into the cli directory: `cd cli`
+2. Go into the CLI directory: `cd cli`
 3. Run `npm install`
-4. Link the cli with: `npm link`
+4. Link the CLI with: `npm link`
 
 `dcl` command should now be available.
 
-For CLI tool development, run `npm start` in your terminal. The cli will use the mainnet address for the LANDProxy contract by default. If you want to change it, you can add a `.env` file on the root folder, with a `LAND_REGISTRY_CONTRACT_ADDRESS` var. It'll use [dotenv](https://github.com/motdotla/dotenv#faq) to fetch the value. You can check the current contract addresses [here](https://contracts.decentraland.org/addresses.json).
+For CLI tool development, run `npm start` in your terminal. The CLI will use the mainnet address for the LANDProxy contract by default. If you want to change it, you can add a `.env` file on the root folder, with a `LAND_REGISTRY_CONTRACT_ADDRESS` var. It'll use [dotenv](https://github.com/motdotla/dotenv#faq) to fetch the value. You can check the current contract addresses [here](https://contracts.decentraland.org/addresses.json).
 
 You can run CLI commands in development mode like this: `npm start -- init`
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "lint:fix": "tslint -c tslint.json 'src/**/*.ts' --fix",
     "tsc": "tsc",
-    "test": "mocha -r ts-node/register src/**/*.spec.ts"
+    "test": "mocha -r ts-node/register src/**/*.spec.ts",
+    "postinstall": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "lint:fix": "tslint -c tslint.json 'src/**/*.ts' --fix",
     "tsc": "tsc",
-    "test": "mocha -r ts-node/register src/**/*.spec.ts",
-    "prepublish": "npm run build"
+    "test": "mocha -r ts-node/register src/**/*.spec.ts"
   },
   "repository": {
     "type": "git",
@@ -35,19 +34,22 @@
   "bin": {
     "dcl": "./bin/dcl"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "dependencies": {
     "@types/uuid": "^3.4.3",
     "axios": "^0.17.1",
     "babel-polyfill": "^6.26.0",
-    "chalk": "^2.3.0",
-    "decentraland-commons": "^2.7.2",
+    "chalk": "^2.3.1",
+    "decentraland-commons": "^2.10.0",
     "docker-names": "^1.0.3",
     "fs-extra": "^5.0.0",
     "get-installed-path": "^4.0.8",
-    "inquirer": "^5.0.0",
-    "ipfs-api": "^17.2.6",
-    "koa": "^2.4.1",
-    "koa-router": "^7.3.0",
+    "inquirer": "^5.1.0",
+    "ipfs-api": "^17.5.0",
+    "koa": "^2.5.0",
+    "koa-router": "^7.4.0",
     "koa-static": "^4.0.2",
     "live-server": "^1.2.0",
     "next": "^4.2.2",
@@ -64,11 +66,11 @@
     "@types/chalk": "^2.2.0",
     "@types/fs-extra": "^5.0.0",
     "@types/inquirer": "0.0.36",
-    "@types/koa": "^2.0.43",
+    "@types/koa": "^2.0.44",
     "@types/koa-router": "^7.0.27",
     "@types/koa-static": "^4.0.0",
-    "@types/mocha": "^2.2.47",
-    "@types/next": "^2.4.7",
+    "@types/mocha": "^2.2.48",
+    "@types/next": "^2.4.8",
     "@types/node": "^8.5.2",
     "@types/opn": "^5.1.0",
     "@types/progress": "^2.0.1",
@@ -85,7 +87,7 @@
     "rimraf": "^2.6.2",
     "ts-node": "^4.1.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.6.2",
+    "typescript": "^2.7.2",
     "uglifyjs-webpack-plugin": "^1.1.6"
   }
 }


### PR DESCRIPTION
- update dependencies with `npm update`
- add requirements and installation info to readme (with links)
- add minimum `node` version we support in `package.json` (8.0.0 and above supports everything we use from ES6)

Closes #58, #63, #67.