### PR TITLE
fix: better startup

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -42,30 +42,30 @@ export function init(vorpal: any) {
           {
             type: 'input',
             name: 'owner',
-            message: `${chalk.blue('Your ethereum address: ')} ${chalk.grey(
-              '(recommended -- used to check ownership of parcels when deploying your scene)'
-            )}`
+            message: `${chalk.blue('Your ethereum address: ')}\n${chalk.grey(
+              '(optional, recommended -- used to check ownership of parcels when deploying your scene)'
+            )}\n`
           },
           {
             type: 'input',
             name: 'contact.name',
-            message: `${chalk.blue('Your name: ')} ${chalk.grey(
+            message: `${chalk.blue('Your name: ')}\n${chalk.grey(
               '(optional -- shown to other users so that they can contact you)'
-            )}`
+            )}\n`
           },
           {
             type: 'input',
             name: 'contact.email',
-            message: `${chalk.blue('Your email: ')} ${chalk.grey(
+            message: `${chalk.blue('Your email: ')}\n${chalk.grey(
               '(optional -- shown to other users so that they can contact you)'
-            )}`
+            )}\n`
           },
           {
             type: 'input',
             name: 'scene.parcels',
-            message: `${chalk.blue('Parcels comprising the scene')} ${chalk.grey(
-              '(recommended -- used to show the limts of your scene and upload to these coordinates)'
-            )}\n ${chalk.blue(`Please use this format: 'x,y; x,y; x,y ...'`)}\n`
+            message: `${chalk.blue('Parcels comprising the scene')}\n${chalk.grey(
+              '(optional, recommended -- used to show the limts of your scene and upload to these coordinates)'
+            )}\n${chalk.blue(`Please use this format: 'x,y; x,y; x,y ...'`)}\n`
           }
         ]);
         sceneMeta.communications = {
@@ -85,18 +85,6 @@ export function init(vorpal: any) {
 
         sceneMeta.main = 'scene.xml'; // replaced by chosen template
         sceneMeta.scene.base = sceneMeta.scene.parcels[0];
-
-        const results = await inquirer.prompt({
-          type: 'confirm',
-          name: 'continue',
-          default: true,
-          message: chalk.yellow('Do you want to continue?')
-        });
-
-        if (!results.continue) {
-          callback();
-          return;
-        }
 
         const dirName = args.options.path || getRoot();
         fs.outputFileSync(
@@ -121,7 +109,8 @@ export function init(vorpal: any) {
             'build.json',
             'tsconfig.json',
             'tslint.json',
-            'node_modules/',
+            'server',
+            '**/node_modules/*',
             '*.ts',
             '*.tsx',
             'dist/'
@@ -141,9 +130,9 @@ export function init(vorpal: any) {
             name: 'archetype',
             message: chalk.yellow('Which type of project would you like to generate?'),
             choices: [
-              { name: 'Static a-minus scene project', value: BoilerplateType.STATIC },
-              { name: 'Dynamic Typescript project', value: BoilerplateType.TYPESCRIPT },
-              { name: 'Remote project (WebSockets)', value: BoilerplateType.WEBSOCKETS }
+              { name: 'Static scene project', value: BoilerplateType.STATIC },
+              { name: 'Dynamic scene (single player)', value: BoilerplateType.TYPESCRIPT },
+              { name: 'Dynamic multiplayer scene (EXPERIMENTAL)', value: BoilerplateType.WEBSOCKETS }
             ],
             default: BoilerplateType.STATIC,
           });
@@ -161,7 +150,7 @@ export function init(vorpal: any) {
             websocketServer = ws.server;
           }
         } else if (!isValidBoilerplateType(boilerplateType)) {
-          vorpal.log(chalk.red(`Invalid boilerplate type. Supported types are 'static', 'ts' and 'ws'.`));
+          vorpal.log(chalk.red(`Invalid boilerplate type. Supported types are 'static', 'singleplayer' and 'multiplayer-experimental'.`));
           process.exit(1);
         }
 
@@ -184,6 +173,7 @@ export function init(vorpal: any) {
             copySample('basic-static');
             break;
         }
+        this.log(`\nRun 'dcl preview' to see your scene`);
       })
     );
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -6,7 +6,8 @@ const opn = require('opn');
 
 export function start(vorpal: any) {
   vorpal
-    .command('start')
+    .command('preview')
+    .alias('start')
     .alias('serve')
     .description('Starts local development server.')
     .action(function(args: any, callback: () => void) {

--- a/src/creation/init.ts
+++ b/src/creation/init.ts
@@ -14,8 +14,8 @@ interface GeneratorSettings {
 
 export enum BoilerplateType {
   STATIC = 'static',
-  TYPESCRIPT = 'ts',
-  WEBSOCKETS = 'ws'
+  TYPESCRIPT = 'singleplayer',
+  WEBSOCKETS = 'multiplayer-experimental'
 }
 
 export async function initProject(args: any, sceneMeta: any) {
@@ -53,6 +53,7 @@ export function isValidBoilerplateType(boilerplateType: string): boolean {
 
 export function scaffoldWebsockets(server: string) {
   overwriteSceneFile({ main: server }, process.cwd());
+  copySample('websockets');
 }
 
 export function overwriteSceneFile(scene: any, destination: string) {

--- a/src/samples/websockets/server/ConnectedClients.tsx
+++ b/src/samples/websockets/server/ConnectedClients.tsx
@@ -1,0 +1,9 @@
+import { RemoteScene } from "./RemoteScene";
+
+export const connectedClients: Set<RemoteScene> = new Set();
+
+export function updateAll() {
+  connectedClients.forEach(function each(client) {
+    client.update();
+  });
+}

--- a/src/samples/websockets/server/RemoteScene.tsx
+++ b/src/samples/websockets/server/RemoteScene.tsx
@@ -1,0 +1,113 @@
+import { createElement } from "dcl-sdk/JSX";
+import {
+  EventSubscriber,
+  Script,
+  inject,
+  EntityController,
+  SoundController
+} from "dcl-sdk";
+import { updateAll } from "./ConnectedClients";
+
+const winingCombinations = [
+  [0, 1, 2], // 1 row
+  [3, 4, 5], // 2 row
+  [6, 7, 8], // 3 row
+
+  [0, 3, 6], // 1 col
+  [1, 4, 7], // 2 col
+  [2, 5, 8], // 3 col
+
+  [0, 4, 8], // nw - se
+  [6, 4, 2] // sw - ne
+];
+
+type GameSymbol = "x" | "o" | null;
+
+let board: GameSymbol[] = [
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null
+];
+
+let currentSymbol: GameSymbol = null;
+
+export class RemoteScene extends Script {
+  @inject("experimentalSoundController") audio: SoundController | null = null;
+  @inject("EntityController") entityController: EntityController | null = null;
+
+  eventSubscriber: EventSubscriber | null = null;
+
+  getWinner() {
+    return ["x", "o"].find($ =>
+      winingCombinations.some(combination =>
+        combination.every(position => board[position] === $)
+      )
+    );
+  }
+
+  selectMySymbol(symbol: GameSymbol) {
+    currentSymbol = symbol;
+  }
+
+  setAt(position: number, symbol: GameSymbol) {
+    board[position] = symbol;
+  }
+
+  async systemDidEnable() {
+    this.eventSubscriber = new EventSubscriber(this.entityController!);
+
+    this.eventSubscriber.on(`reset_click`, async (evt: any) => {
+      board = board.map(() => null);
+      updateAll();
+      await this.audio!.playSound("sounds/sound.ogg");
+    });
+
+    this.selectMySymbol("x");
+
+    board.map(($, $$) =>
+      this.eventSubscriber!.on(`position-${$$}_click`, async (evt: any) => {
+        this.setAt($$, currentSymbol);
+
+        updateAll();
+
+        this.selectMySymbol(currentSymbol === "x" ? "o" : "x");
+
+        if (this.getWinner()) {
+          await this.audio!.playSound("sounds/Nyan_cat.ogg");
+        }
+
+        await this.audio!.playSound("sounds/sound.ogg");
+      })
+    );
+
+    await this.render();
+  }
+
+  async render() {
+    const game = (
+      <a-scene>
+        <a-cube position="5 5 5" color="red" id="reset" />
+        {board.map(($, ix) => (
+          <a-cube
+            id={`position-${ix}`}
+            color={$ === null ? "black" : $ === "x" ? "red" : "green"}
+            position={`${ix % 3} 0.2 ${Math.floor(ix / 3)}`}
+            scale="0.8 0.1 0.8"
+          />
+        ))}
+      </a-scene>
+    );
+    await this.entityController!.render(game);
+  }
+
+  /** this method is called when we want to globally update the parcels */
+  update() {
+    this.render();
+  }
+}

--- a/src/samples/websockets/server/Server.tsx
+++ b/src/samples/websockets/server/Server.tsx
@@ -1,0 +1,26 @@
+import { static as serveStatic } from "express";
+import { createServer } from "http";
+import { Server as WebSocketServer } from "ws";
+import { RemoteScene } from "./RemoteScene";
+import { connectedClients } from "./ConnectedClients";
+import { WebSocketTransport } from "dcl-sdk";
+
+const app = require("express")();
+
+app.use(require("cors")());
+app.use(serveStatic("client"));
+
+const server = createServer(app);
+
+const wss = new WebSocketServer({ server });
+
+wss.on("connection", function connection(ws, req) {
+  const client = new RemoteScene(WebSocketTransport(ws));
+  connectedClients.add(client);
+  ws.on("close", () => connectedClients.delete(client));
+  console.log("Client connected", client);
+});
+
+server.listen(6060, function listening() {
+  console.log(`Listening on`, server.address());
+});

--- a/src/samples/websockets/server/index.tsx
+++ b/src/samples/websockets/server/index.tsx
@@ -1,0 +1,18 @@
+// We use esnext in dcl-sdk, webpack and rollup handle it natively but not Node.js
+
+const traceur = require("traceur");
+
+// replace node.js require by traceur's
+traceur.require.makeDefault(
+  function(filename: string) {
+    // transpile every file
+    console.log(filename);
+    return true;
+  },
+  {
+    asyncFunctions: true,
+    asyncGenerators: true
+  }
+);
+
+require("./Server");


### PR DESCRIPTION
This PR:

* Renames "dynamic" and "remote" to "singleplayer" and "multiplayer"
* Reenforces the fact that `ethereum address` and `parcels` are optional steps
* Drops unnecessary "do you want to proceed?"
* Adds boilerplate server generation
* Introduces `dcl preview` as better alias for `dcl start` and names that at the end of the initialization