### PR TITLE
feat: allow any sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "CLI tool for parcel management.",
   "main": "./dist/index.js",
   "scripts": {
@@ -27,10 +27,7 @@
     "singleQuote": true,
     "printWidth": 120
   },
-  "keywords": [
-    "decentraland",
-    "cli"
-  ],
+  "keywords": ["decentraland", "cli"],
   "author": "Decentraland",
   "license": "Apache-2.0",
   "bugs": {
@@ -44,6 +41,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
+    "@types/analytics-node": "0.0.31",
     "@types/uuid": "^3.4.3",
     "analytics-node": "^3.2.0",
     "axios": "^0.17.1",

--- a/pages/linker.js
+++ b/pages/linker.js
@@ -1,7 +1,7 @@
 import 'babel-polyfill';
 import React from 'react';
 import Router from 'next/router';
-import { eth, txUtils, contracts } from 'decentraland-commons';
+import { eth, txUtils, contracts } from 'decentraland-commons/dist/browser';
 const { LANDRegistry } = contracts;
 
 async function ethereum() {

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -3,4 +3,7 @@ import { postInstall, cliInstalled } from './utils/analytics';
 (async function() {
   await postInstall();
   await cliInstalled();
-})();
+})().catch(e => {
+  // tslint:disable-next-line:no-console
+  console.error(e);
+});

--- a/src/preview/serve.ts
+++ b/src/preview/serve.ts
@@ -8,7 +8,7 @@ import { cliPath } from '../utils/cli-path';
 import { preview } from '../utils/analytics';
 
 export function serve(vorpal: any, args: any): any {
-  vorpal.log(chalk.blue('Parcel server is starting...\n'));
+  vorpal.log(chalk.blue('Preview server is starting...\n'));
 
   const root = getRoot();
 
@@ -30,8 +30,16 @@ export function serve(vorpal: any, args: any): any {
     `);
   });
 
-  // serve the folder `dcl-sdk/artifacts` as `/dcl-sdk`
-  app.use('/dcl-sdk', express.static(path.dirname(require.resolve('dcl-sdk/artifacts/preview'))));
+  // first find the target path's node_modules/dcl-sdk
+  let sdkFolder = path.resolve(process.cwd(), 'node_modules/dcl-sdk');
+
+  // if it doesn't exist, use the bundled SDK
+  if (!fs.existsSync(sdkFolder)) {
+    sdkFolder = path.dirname(require.resolve('dcl-sdk'));
+  }
+
+  // serve the folder `${sdkFolder}/artifacts` as `/dcl-sdk`
+  app.use('/dcl-sdk', express.static(path.resolve(sdkFolder, 'artifacts')));
   app.use(express.static(root));
   app.listen(2044, '0.0.0.0');
   return app;

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -4,7 +4,7 @@ import * as uuidv4 from 'uuid/v4';
 
 import { cliPath } from './cli-path';
 
-const Analytics = require('analytics-node');
+import Analytics = require('analytics-node');
 
 import { ensureFolder, pathExists, readFile, writeFile } from './filesystem';
 import { isDev } from './is-dev';
@@ -32,11 +32,11 @@ export const deploy = track('Scene deploy requested');
 export async function postInstall() {
   const userId = await getUserId();
   analytics.identify({
-    SINGLEUSER,
+    userId: SINGLEUSER,
     traits: {
       os: process.platform,
       createdAt: new Date().getTime(),
-      devId: userId,
+      devId: userId
     }
   });
 }


### PR DESCRIPTION
- `dcl start` now looks for a local `dcl-sdk` installed in the folder it is executing
- Fixes a couple of bugs


Testing strategy:

- Fetch this branch
- `npm run build`
- `npm link` (links the global `dcl` command to this folder)
- Create a new typescript project, install the latest SDK in that folder, use it with the `Component` feature and it should work