### PR TITLE
fix: validateNewProject

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "singleQuote": true,
     "printWidth": 140
   },
-  "keywords": ["decentraland", "cli"],
+  "keywords": [
+    "decentraland",
+    "cli"
+  ],
   "author": "Decentraland",
   "license": "Apache-2.0",
   "bugs": {
@@ -76,6 +79,7 @@
     "@types/react-dom": "^16.0.4",
     "@types/sinon": "^4.3.1",
     "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "cross-env": "^5.1.3",
     "mocha": "^4.1.0",
     "prettier": "^1.9.2",

--- a/src/lib/Project.ts
+++ b/src/lib/Project.ts
@@ -10,7 +10,8 @@ import {
   SCENE_FILE,
   getIgnoreFilePath,
   IProjectFile,
-  DCLIGNORE_FILE
+  DCLIGNORE_FILE,
+  getDecentralandFolderPath
 } from '../utils/project'
 import * as parser from 'gitignore-parser'
 import { IIPFSFile } from './IPFS'
@@ -28,6 +29,13 @@ export class Project {
    */
   sceneFileExists(): Promise<boolean> {
     return fs.pathExists(getSceneFilePath())
+  }
+
+  /**
+   * Returns `true` if the provided path contains a `.decentraland` folder
+   */
+  decentralandFolderExists(): Promise<boolean> {
+    return fs.pathExists(getDecentralandFolderPath())
   }
 
   /**
@@ -194,7 +202,7 @@ export class Project {
    * Throws if a project already exists or if the directory is not empty.
    */
   async validateNewProject() {
-    if (await this.sceneFileExists()) {
+    if ((await this.sceneFileExists()) || (await this.decentralandFolderExists())) {
       fail(ErrorType.PROJECT_ERROR, 'Project already exists')
     }
   }

--- a/test/lib/project.spec.ts
+++ b/test/lib/project.spec.ts
@@ -1,22 +1,28 @@
-import { expect } from 'chai'
+import { expect, use } from 'chai'
 import { sandbox } from 'sinon'
+const chaiAsPromised = require('chai-as-promised')
 
 import * as fs from 'fs-extra'
 import { Project } from '../../src/lib/Project'
 
+use(chaiAsPromised)
 const ctx = sandbox.create()
 
 describe('Project class', () => {
   let getAllFilePathsStub
   let getDCLIgnoreStub
-  let readFileSyncStub
+  let readFileStub
+  let sceneFileExistsStub
+  let decentralandFolderExistsStub
 
   beforeEach(() => {
     getAllFilePathsStub = ctx
       .stub(Project.prototype, 'getAllFilePaths')
       .callsFake(() => ['a.json', 'src/b.json', 'node_modules/module/a.js', 'src/node_modules/module/b.js', '.dclignore'])
     getDCLIgnoreStub = ctx.stub(Project.prototype, 'getDCLIgnore' as any).callsFake(() => '')
-    readFileSyncStub = ctx.stub(fs, 'readFile').callsFake(path => 'buffer')
+    sceneFileExistsStub = ctx.stub(Project.prototype, 'sceneFileExists').callsFake(() => false)
+    decentralandFolderExistsStub = ctx.stub(Project.prototype, 'decentralandFolderExists').callsFake(() => false)
+    readFileStub = ctx.stub(fs, 'readFile').callsFake(path => 'buffer')
   })
 
   afterEach(function() {
@@ -110,6 +116,27 @@ describe('Project class', () => {
       expect(files).to.satisfy((files: any[]) => {
         return !files.some(file => file.path === 'a.json' || file.path === 'src/b.json')
       })
+    })
+  })
+
+  describe('validateNewProject', () => {
+    it('should pass if the working directory is not dirty', async () => {
+      const project = new Project()
+      expect(await project.validateNewProject.bind(project)).to.not.throw()
+    })
+
+    it('should fail if the working directory contains a scene.json file', async () => {
+      decentralandFolderExistsStub.callsFake(() => false)
+      sceneFileExistsStub.callsFake(() => true)
+      const project = new Project()
+      return expect(project.validateNewProject()).to.be['rejected']
+    })
+
+    it('should fail if the working directory contains a .decentraland folder', async () => {
+      sceneFileExistsStub.callsFake(() => false)
+      decentralandFolderExistsStub.callsFake(() => true)
+      const project = new Project()
+      return expect(project.validateNewProject()).to.be['rejected']
     })
   })
 })

--- a/test/lib/project.spec.ts
+++ b/test/lib/project.spec.ts
@@ -120,23 +120,23 @@ describe('Project class', () => {
   })
 
   describe('validateNewProject', () => {
-    it('should pass if the working directory is not dirty', async () => {
+    it('should pass if the working directory is not dirty', () => {
       const project = new Project()
-      expect(await project.validateNewProject.bind(project)).to.not.throw()
+      expect(project.validateNewProject(), 'expect validateNewProject not to fail').to.be['fulfilled']
     })
 
     it('should fail if the working directory contains a scene.json file', async () => {
       decentralandFolderExistsStub.callsFake(() => false)
       sceneFileExistsStub.callsFake(() => true)
       const project = new Project()
-      return expect(project.validateNewProject()).to.be['rejected']
+      return expect(project.validateNewProject(), 'expect validateNewProject fail').to.be['rejectedWith']('Project already exists')
     })
 
     it('should fail if the working directory contains a .decentraland folder', async () => {
       sceneFileExistsStub.callsFake(() => false)
       decentralandFolderExistsStub.callsFake(() => true)
       const project = new Project()
-      return expect(project.validateNewProject()).to.be['rejected']
+      return expect(project.validateNewProject(), 'expect validateNewProject fail').to.be['rejectedWith']('Project already exists')
     })
   })
 })

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["tslint-no-circular-imports", "dcl-tslint-config-standard"],
+  "extends": ["dcl-tslint-config-standard"],
   "rules": {
     "quotemark": false,
     "no-console": true,


### PR DESCRIPTION
Closes [CLIENT-41](https://decentraland.atlassian.net/browse/CLIENT-41)

A project now fails to init if there's an existing `.decentraland` folder or an existing `scene.json` file.