### PR TITLE
chore: changed NODE_ENV to DCL_ENV for internal use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ CLI tool for parcel management.
 
 ## Requirements
 
-- [NodeJS v8 and above](https://github.com/decentraland/cli#nodejs-installation)
-- [Python 2.7](https://www.python.org/downloads/)
-- [IPFS](https://dist.ipfs.io/#go-ipfs)
+* [NodeJS v8 and above](https://github.com/decentraland/cli#nodejs-installation)
+* [Python 2.7](https://www.python.org/downloads/)
+* [IPFS](https://dist.ipfs.io/#go-ipfs)
 
 ## NodeJS Installation
 
 ### MacOS/Linux:
 
-You need to have NodeJS (version 8.*.* and above) installed on your system to use the CLI. You can use official NodeJS installer, but on MacOS/Linux we recommend to use [NVM](https://github.com/creationix/nvm) for managing your NodeJS installation. Please follow the installation instructions.
+You need to have NodeJS (version 8._._ and above) installed on your system to use the CLI. You can use official NodeJS installer, but on MacOS/Linux we recommend to use [NVM](https://github.com/creationix/nvm) for managing your NodeJS installation. Please follow the installation instructions.
 
 ```bash
 $ npm install -g decentraland
@@ -38,31 +38,31 @@ This should install CLI tool and make it available globally. Please proceed to [
 
 Thanks @HAZARDU5 for this guide
 
-1. Install Node.js v8 LTS from https://nodejs.org/en/download/
+1.  Install Node.js v8 LTS from https://nodejs.org/en/download/
 
-2. Search Windows for *cmd* and right click the *Command Prompt* app and select *Run as Administrator*
+2.  Search Windows for _cmd_ and right click the _Command Prompt_ app and select _Run as Administrator_
 
-3. Install windows-build-tools: `npm install --global --production windows-build-tools`
+3.  Install windows-build-tools: `npm install --global --production windows-build-tools`
 
-4. Wait for both the Visual Studio Build Tools and Python installers to both read *Successfully installed xxxx*. When everything is done it will return you to the command prompt.
+4.  Wait for both the Visual Studio Build Tools and Python installers to both read _Successfully installed xxxx_. When everything is done it will return you to the command prompt.
 
-5. Download git (you'll likely want the 64-bit Windows version): https://git-scm.com/download/win
+5.  Download git (you'll likely want the 64-bit Windows version): https://git-scm.com/download/win
 
-6. Install git and when prompted choose to install git bash
+6.  Install git and when prompted choose to install git bash
 
-7. When prompted for a default text editor select *Use the Nano editor by default*
+7.  When prompted for a default text editor select _Use the Nano editor by default_
 
-8. When prompted to adjust your path environment, select *Use Git from the Windows Command Prompt*
+8.  When prompted to adjust your path environment, select _Use Git from the Windows Command Prompt_
 
-9. When prompted to choose the SSH executable, select *Use OpenSSH*
+9.  When prompted to choose the SSH executable, select _Use OpenSSH_
 
-10. When prompted to choose the HTTPS transport backend, select *Use the OpenSSL library*
+10. When prompted to choose the HTTPS transport backend, select _Use the OpenSSL library_
 
-11. When prompted to configure the line ending conversions, select *Checkout Windows-style, commit Unix-style line endings*
+11. When prompted to configure the line ending conversions, select _Checkout Windows-style, commit Unix-style line endings_
 
-12. When prompted to configure the terminal emulator to use with Git Bash select *Use MinTTY*
+12. When prompted to configure the terminal emulator to use with Git Bash select _Use MinTTY_
 
-13. On the final installation screen select the following options: *Enable file system caching* and *Enable Git Credential Manager* and *Enable symbolic links*
+13. On the final installation screen select the following options: _Enable file system caching_ and _Enable Git Credential Manager_ and _Enable symbolic links_
 
 14. Run `npm install -g decentraland`
 
@@ -72,19 +72,19 @@ Thanks @HAZARDU5 for this guide
 
 ## Usage
 
-- Initialize new Decentraland project **from working directory**:
+* Initialize new Decentraland project **from working directory**:
 
 ```bash
 $ dcl init
 ```
 
-- Start local development server and serve your a-minus scene:
+* Start local development server and serve your a-minus scene:
 
 ```bash
 $ dcl start
 ```
 
-- Upload scene to IPFS:
+* Upload scene to IPFS:
 
 First, you need to have IPFS installed locally. Download it [here](https://ipfs.io/docs/install/).
 Note: You need to have IPFS daemon running for this to work!
@@ -93,13 +93,13 @@ Note: You need to have IPFS daemon running for this to work!
 $ dcl upload
 ```
 
-- Link Ethereum to the current scene and pin scene to Decentraland IPFS node:
+* Link Ethereum to the current scene and pin scene to Decentraland IPFS node:
 
 ```bash
 $ dcl link
 ```
 
-- Upload scene to IPFS, update IPNS and link Ethereum to the current scene in one go:
+* Upload scene to IPFS, update IPNS and link Ethereum to the current scene in one go:
 
 ```bash
 $ dcl push
@@ -109,8 +109,8 @@ $ dcl push
 
 If you encounter a message `Ethereum linker app is outdated! Please run dcl upgrade!`, you need to update the Ethereum linker inside your Decentraland project:
 
-1. `cd your-dcl-project`
-2. `dcl upgrade`
+1.  `cd your-dcl-project`
+2.  `dcl upgrade`
 
 To update the CLI tool:
 
@@ -120,14 +120,14 @@ $ npm update -g decentraland
 
 ## Building
 
-1. Clone the repo: `git clone https://github.com/decentraland/cli.git`
-2. Go into the CLI directory: `cd cli`
-3. Run `npm install`
-4. Link the CLI with: `npm link`
+1.  Clone the repo: `git clone https://github.com/decentraland/cli.git`
+2.  Go into the CLI directory: `cd cli`
+3.  Run `npm install`
+4.  Link the CLI with: `npm link`
 
 `dcl` command should now be available.
 
-For CLI tool development, run `npm start` in your terminal. The CLI will use the mainnet address for the LANDProxy contract by default. If you want to change it, you can add a `.env` file on the root folder, with a `LAND_REGISTRY_CONTRACT_ADDRESS` var. It'll use [dotenv](https://github.com/motdotla/dotenv#faq) to fetch the value. You can check the current contract addresses [here](https://contracts.decentraland.org/addresses.json).
+For CLI tool development, run `npm run watch` in your terminal and `npm link` in order to use it anywhere. The CLI will use the mainnet address for the LANDProxy contract by default. If you want to change it, you can define the `LAND_REGISTRY_CONTRACT_ADDRESS` environment variable. You can also use `DCL_ENV=dev` to point to the Ropsten contract. Contract addresses are available [here](https://contracts.decentraland.org/addresses.json).
 
 For the Decentraland IPFS node, we are getting the url from [here](decentraland.github.io/ipfs-node/url.json). If you want to set a different url set the `IPFS_GATEWAY` var in the `.env` file.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2118,20 +2118,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "decentraland-commons": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/decentraland-commons/-/decentraland-commons-3.6.0.tgz",
-      "integrity": "sha1-gj4A4sT//74STLMymxbuajBjE/c=",
-      "requires": {
-        "@ledgerhq/hw-app-eth": "2.2.0",
-        "@ledgerhq/hw-transport-u2f": "2.2.0",
-        "comma-separated-values": "3.6.4",
-        "ethereumjs-util": "5.1.5",
-        "ledger-wallet-provider": "2.0.1-beta.2",
-        "web3": "0.20.6",
-        "web3-provider-engine": "git+https://github.com/decentraland/provider-engine.git#00eabad4c2a09698e23f44d811aec3e662c11841"
-      }
-    },
     "decentraland-eth": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/decentraland-eth/-/decentraland-eth-1.1.3.tgz",
@@ -4963,19 +4949,6 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
         "invert-kv": "1.0.0"
-      }
-    },
-    "ledger-wallet-provider": {
-      "version": "2.0.1-beta.2",
-      "resolved": "https://registry.npmjs.org/ledger-wallet-provider/-/ledger-wallet-provider-2.0.1-beta.2.tgz",
-      "integrity": "sha512-+RWWe67o6Pk2LPhNGIdA5H4LorIsYzL21gexjvoACMO5LsdqLZ08Tuw7LoOWRfsl0LpP7b+AYoup4juHrre9vA==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "ethereumjs-tx": "1.3.4",
-        "ledgerco": "1.2.1",
-        "promise-timeout": "1.3.0",
-        "strip-hex-prefix": "1.0.0",
-        "web3-provider-engine": "git+https://github.com/decentraland/provider-engine.git#00eabad4c2a09698e23f44d811aec3e662c11841"
       }
     },
     "ledgerco": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "singleQuote": true,
     "printWidth": 140
   },
-  "keywords": ["decentraland", "cli"],
+  "keywords": [
+    "decentraland",
+    "cli"
+  ],
   "author": "Decentraland",
   "license": "Apache-2.0",
   "bugs": {
@@ -45,7 +48,6 @@
     "analytics-node": "^3.2.0",
     "axios": "^0.17.1",
     "chalk": "^2.3.1",
-    "decentraland-commons": "^3.1.1",
     "decentraland-eth": "^1.1.3",
     "docker-names": "^1.0.3",
     "express": "^4.16.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CLI tool for parcel management.",
   "main": "./dist/index.js",
   "scripts": {
-    "start": "(mkdir tmp > /dev/null 2>&1 || true) && cd tmp && NODE_ENV=dev ../bin/dcl",
+    "start": "(mkdir tmp > /dev/null 2>&1 || true) && cd tmp && DCL_ENV=dev ../bin/dcl",
     "watch": "tsc --watch & metaverse-compiler build.json --watch",
     "build": "npm run clean && tsc && npm run linker:build && npm run copy:samples",
     "copy:samples": "cp -r src/samples dist/samples",
@@ -26,10 +26,7 @@
     "singleQuote": true,
     "printWidth": 140
   },
-  "keywords": [
-    "decentraland",
-    "cli"
-  ],
+  "keywords": ["decentraland", "cli"],
   "author": "Decentraland",
   "license": "Apache-2.0",
   "bugs": {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -109,7 +109,7 @@ export function init(vorpal: any) {
           await installDependencies()
         }
 
-        await Analytics.sceneCreated()
+        await Analytics.sceneCreated({ boilerplateType })
 
         vorpal.log(success(`\nSuccess! Run 'dcl preview' to see your scene`))
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 /// <reference path="../typings/dcl.d.ts" />
 /// <reference path="../typings/docker-names.d.ts" />
-/// <reference path="../typings/decentraland-commons.d.ts" />
 
 import Vorpal = require('vorpal')
 import { help } from './commands/help'
@@ -10,11 +9,8 @@ import { start } from './commands/preview'
 import { upgrade } from './commands/upgrade'
 import { deploy } from './commands/deploy'
 import { command as pin } from './commands/pin'
-import { env } from 'decentraland-commons/dist/env'
 
 const pkg = require('../package.json')
-
-env.load()
 
 /**
  * Export the current version.

--- a/src/lib/Ethereum.ts
+++ b/src/lib/Ethereum.ts
@@ -15,7 +15,7 @@ export class Ethereum extends EventEmitter {
   static isConnected: boolean = false
 
   /**
-   * Connects to an external Ethereum node based on the NODE_ENV.
+   * Connects to an external Ethereum node based on the DCL_ENV.
    */
   static async connect() {
     const address = await Ethereum.getLandContractAddress()
@@ -39,7 +39,7 @@ export class Ethereum extends EventEmitter {
   /**
    * Returns the LandProxy contract address.
    * If the LAND_REGISTRY_CONTRACT_ADDRESS is specified, that value will be returned.
-   * Otherwise, an external resources will be queried and the address will be resturned based on the NODE_ENV.
+   * Otherwise, an external resources will be queried and the address will be resturned based on the DCL_ENV.
    */
   static async getLandContractAddress(): Promise<string> {
     const envContract = env.get('LAND_REGISTRY_CONTRACT_ADDRESS')

--- a/src/lib/Ethereum.ts
+++ b/src/lib/Ethereum.ts
@@ -1,7 +1,6 @@
 import { isDev } from '../utils/env'
 import axios from 'axios'
 import { contracts, eth } from 'decentraland-eth'
-import { env } from 'decentraland-commons/dist/env'
 import { EventEmitter } from 'events'
 import { ErrorType, fail } from '../utils/errors'
 
@@ -20,7 +19,7 @@ export class Ethereum extends EventEmitter {
   static async connect() {
     const address = await Ethereum.getLandContractAddress()
     const land = new contracts.LANDRegistry(address)
-    const providerUrl = env.get('RPC_URL', () => (isDev ? 'https://ropsten.infura.io/' : 'https://mainnet.infura.io/'))
+    const providerUrl = process.env.RPC_URL || (isDev ? 'https://ropsten.infura.io/' : 'https://mainnet.infura.io/')
 
     if (!Ethereum.isConnected) {
       try {
@@ -42,7 +41,7 @@ export class Ethereum extends EventEmitter {
    * Otherwise, an external resources will be queried and the address will be resturned based on the DCL_ENV.
    */
   static async getLandContractAddress(): Promise<string> {
-    const envContract = env.get('LAND_REGISTRY_CONTRACT_ADDRESS')
+    const envContract = process.env.LAND_REGISTRY_CONTRACT_ADDRESS
 
     if (envContract) {
       return envContract

--- a/src/lib/IPFS.ts
+++ b/src/lib/IPFS.ts
@@ -1,4 +1,3 @@
-import { env } from 'decentraland-commons/dist/env'
 import axios from 'axios'
 import { EventEmitter } from 'events'
 import { isDev } from '../utils/env'
@@ -152,6 +151,6 @@ export class IPFS extends EventEmitter {
       // fallback to ENV
     }
 
-    return env.get('IPFS_GATEWAY', () => ipfsURL)
+    return process.env.IPFS_GATEWAY || ipfsURL
   }
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,4 @@
 /**
  * Check if CLI is used in development mode.
  */
-export const isDev: boolean = process.env.NODE_ENV === 'dev'
+export const isDev: boolean = process.env.DCL_ENV === 'dev'

--- a/typings/decentraland-commons.d.ts
+++ b/typings/decentraland-commons.d.ts
@@ -1,6 +1,0 @@
-declare module 'decentraland-commons/dist/env' {
-  namespace env {
-    export function load(): void
-    export function get(name: string, fallback?: () => any): string
-  }
-}


### PR DESCRIPTION
Changes NODE_ENV usage to DCL_ENV for internal use. We want to free NODE_ENV for end users without changing to ropsten.

Closes [CLIENT-80](https://decentraland.atlassian.net/browse/CLIENT-80)