### PR TITLE
fix: resolve promise even when tracking disabled

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -90,6 +90,8 @@ async function track(eventName: string, properties: any = {}) {
         }
         resolve()
       })
+    } else {
+      resolve()
     }
   })
 }


### PR DESCRIPTION
If user disabled sending usage info, commands should work (Promise now resolves).