### PR TITLE
fix: require dclignore for deployments but not for preview

### DIFF
--- a/src/lib/Project.ts
+++ b/src/lib/Project.ts
@@ -28,7 +28,7 @@ export interface IFile {
 }
 
 export class Project {
-  private static MAX_FILE_SIZE = 5243000000
+  private static MAX_FILE_SIZE = 524300000
   private workingDir: string
 
   constructor(workingDir: string) {
@@ -311,8 +311,7 @@ export class Project {
       const stat = await fs.stat(filePath)
 
       if (stat.size > Project.MAX_FILE_SIZE) {
-        // MAX_FILE_SIZE is an arbitrary file size, V8 will probably fail to read files larger than 2147483647 bytes,
-        // while ChakraCore has other limits. For more info see: https://github.com/nodejs/node/issues/9489
+        // MAX_FILE_SIZE is an arbitrary file size
         fail(ErrorType.IPFS_ERROR, `Maximum file size exceeded: '${file}' is larger than ${Project.MAX_FILE_SIZE} bytes`)
       }
 

--- a/src/samples/basic-static/package.json
+++ b/src/samples/basic-static/package.json
@@ -5,6 +5,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "metaverse-api": "rc"
+    "metaverse-api": "^4.0.0"
   }
 }

--- a/src/samples/basic-ts/package.json
+++ b/src/samples/basic-ts/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "metaverse-api": "rc",
+    "metaverse-api": "^4.0.0",
     "typescript": "^2.7.2"
   }
 }

--- a/src/samples/websockets/package.json
+++ b/src/samples/websockets/package.json
@@ -5,6 +5,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "metaverse-api": "rc"
+    "metaverse-api": "^4.0.0"
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -4,7 +4,8 @@ export enum ErrorType {
   IPFS_ERROR = 'IPFSError',
   PROJECT_ERROR = 'ProjectError',
   PREVIEW_ERROR = 'PreviewError',
-  UPGRADE_ERROR = 'UpgradeError'
+  UPGRADE_ERROR = 'UpgradeError',
+  DEPLOY_ERROR = 'DeployError'
 }
 
 export function fail(type: ErrorType, message: string) {

--- a/test/integration/lib/project.spec.ts
+++ b/test/integration/lib/project.spec.ts
@@ -58,8 +58,9 @@ tmpTest(async (dirPath, done) => {
     describe('getFiles()', async () => {
       it('should return all the files qualified to be uploaded', async () => {
         const project = new Project(dirPath)
-        const result = await project.getFiles()
-
+        const result = await project.getFiles(
+          `.*\npackage.json\npackage-lock.json\nyarn-lock.json\nbuild.json\ntsconfig.json\ntslint.json\nnode_modules/\n*.ts\n*.tsx\ndist/`
+        )
         expect(result.map(f => f.path)).to.deep.equal(['models/test.fbx', 'scene.json', 'scene.xml', 'test.js'])
       }).timeout(5000)
     })

--- a/test/unit/lib/project.spec.ts
+++ b/test/unit/lib/project.spec.ts
@@ -10,7 +10,6 @@ const ctx = sandbox.create()
 
 describe('Project', () => {
   let getAllFilePathsStub
-  let getDCLIgnoreStub
   let readFileStub
   let sceneFileExistsStub
   let decentralandFolderExistsStub
@@ -20,7 +19,6 @@ describe('Project', () => {
     getAllFilePathsStub = ctx
       .stub(Project.prototype, 'getAllFilePaths')
       .callsFake(() => ['a.json', 'src/b.json', 'node_modules/module/a.js', 'src/node_modules/module/b.js', '.dclignore'])
-    getDCLIgnoreStub = ctx.stub(Project.prototype, 'getDCLIgnore' as any).callsFake(() => '')
     sceneFileExistsStub = ctx.stub(Project.prototype, 'sceneFileExists').callsFake(() => false)
     decentralandFolderExistsStub = ctx.stub(Project.prototype, 'decentralandFolderExists').callsFake(() => false)
     readFileStub = ctx.stub(fs, 'readFile').callsFake(path => 'buffer')
@@ -35,7 +33,7 @@ describe('Project', () => {
   describe('getFiles()', () => {
     it('should return all files', async () => {
       const project = new Project('.')
-      const files = await project.getFiles()
+      const files = await project.getFiles('')
       const expected = ['a.json', 'src/b.json', 'node_modules/module/a.js', 'src/node_modules/module/b.js', '.dclignore']
 
       files.forEach((file, i) => {
@@ -46,10 +44,8 @@ describe('Project', () => {
     })
 
     it('should ignore node_modules', async () => {
-      getDCLIgnoreStub.callsFake(() => `node_modules`)
-
       const project = new Project('.')
-      const files = await project.getFiles()
+      const files = await project.getFiles('node_modules')
       const expected = ['a.json', 'src/b.json', '.dclignore']
 
       files.forEach((file, i) => {
@@ -64,10 +60,8 @@ describe('Project', () => {
     })
 
     it('should ignore . files', async () => {
-      getDCLIgnoreStub.callsFake(() => `.*`)
-
       const project = new Project('.')
-      const files = await project.getFiles()
+      const files = await project.getFiles('.*')
       const expected = ['a.json', 'src/b.json', 'node_modules/module/a.js', 'src/node_modules/module/b.js']
 
       files.forEach((file, i) => {
@@ -82,10 +76,8 @@ describe('Project', () => {
     })
 
     it('should ignore specific file', async () => {
-      getDCLIgnoreStub.callsFake(() => `a.json`)
-
       const project = new Project('.')
-      const files = await project.getFiles()
+      const files = await project.getFiles('a.json')
       const expected = ['src/b.json', 'node_modules/module/a.js', 'src/node_modules/module/b.js', '.dclignore']
 
       files.forEach((file, i) => {
@@ -100,10 +92,8 @@ describe('Project', () => {
     })
 
     it('should ignore several files', async () => {
-      getDCLIgnoreStub.callsFake(() => `a.json\nsrc/b.json`)
-
       const project = new Project('.')
-      const files = await project.getFiles()
+      const files = await project.getFiles('a.json\nsrc/b.json')
       const expected = ['node_modules/module/a.js', 'src/node_modules/module/b.js', '.dclignore']
 
       files.forEach((file, i) => {


### PR DESCRIPTION
- require .dclignore for deployments
- autogenerate it if missing
- preview should work without .dclignore