### PR TITLE
feat: better lifecycle for linker app

### DIFF
--- a/linker-app/src/index.tsx
+++ b/linker-app/src/index.tsx
@@ -34,7 +34,7 @@ async function getIPFSKey() {
 }
 
 async function closeServer(ok, message) {
-  console.log('closing server:', message)
+  console.log('sending error to server:', message)
   await fetch(`/api/close?ok=${ok}&reason=${message}`)
 }
 
@@ -184,7 +184,6 @@ export default class Page extends React.Component<
       this.setState({ transactionLoading: false })
       await closeServer(true, 'success')
       window.removeEventListener('beforeunload', this.onUnload)
-      window.close()
     }
   }
 

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -25,12 +25,21 @@ export function link(vorpal: any) {
         dcl.on('link:ready', async url => {
           await Analytics.sceneLink()
           const linkerMsg = loading(`Linking app ready at ${url}`)
-          opn(url)
+          try {
+            opn(url)
+          } catch (error) {
+            linkerMsg.info('Could not open browser automatically.')
+          }
 
           dcl.on('link:success', async () => {
             await Analytics.sceneLinkSuccess()
             linkerMsg.succeed('Project successfully updated in LAND Registry')
             process.exit(1)
+          })
+
+          dcl.on('link:error', async (error) => {
+            linkerMsg.info('Linker app error: ' + error.message)
+            linkerMsg.info(`Press Ctrl+C to exit, or try to link again from ${url}`)
           })
         })
 

--- a/src/lib/Ethereum.ts
+++ b/src/lib/Ethereum.ts
@@ -3,13 +3,18 @@ import * as fetch from 'isomorphic-fetch'
 import { EventEmitter } from 'events'
 import { ErrorType, fail } from '../utils/errors'
 import * as CSV from 'comma-separated-values'
-const { abi } = require('../../abi/LANDRegistry.json')
+const { landRegistryABI } = require('../../abi/LANDRegistry.json')
 import { RequestManager, ContractFactory, providers } from 'eth-connect'
 
 const provider = process.env.RPC_URL || (isDev ? 'https://ropsten.infura.io/' : 'https://mainnet.infura.io/')
 const requestManager = new RequestManager(new providers.HTTPProvider(provider))
-const factory = new ContractFactory(requestManager, abi)
-export const landContract = factory.at(isDev ? '0x7a73483784ab79257bb11b96fd62a2c3ae4fb75b' : '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d')
+const landRegistryFactory = new ContractFactory(requestManager, landRegistryABI)
+
+// TODO: Warning, the `at` method might have side-effects and this line might lead to race conditions
+export const landContract = landRegistryFactory.at(isDev
+  ? '0x7a73483784ab79257bb11b96fd62a2c3ae4fb75b'
+  : '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d'
+)
 
 /**
  * Events emitted by this class:

--- a/src/lib/LinkerAPI.ts
+++ b/src/lib/LinkerAPI.ts
@@ -41,10 +41,6 @@ export class LinkerAPI extends EventEmitter {
 
       this.setRoutes()
 
-      this.on('link:error', err => {
-        reject(err)
-      })
-
       this.app.listen(resolvedPort, () => this.emit('link:ready', url)).on('error', (e: any) => {
         if (e.errno === 'EADDRINUSE') {
           reject(new Error(`Port ${resolvedPort} is already in use by another process`))


### PR DESCRIPTION
This pull request:

* Decouples the interaction and reliance on the browser window to control the lifecycle of the server
  - Do not close the server on the first error (if metamask is locked, the server exits immediately)
  - Do not close the tab on success (it's ok to have the tab open after success)
* Removes an error when using `dcl` in a docker vm where `open` is not available
* Minor TODO added to `Ethereum.ts`