### PR TITLE
fix: correctly parse IPFS key

### DIFF
--- a/linker-app/src/modules/Server.ts
+++ b/linker-app/src/modules/Server.ts
@@ -48,7 +48,8 @@ export class Server {
 
   static async getIPFSKey(): Promise<any> {
     try {
-      return await fetch('/api/ipfs-key')
+      const response = await fetch('/api/ipfs-key')
+      return await response.json()
     } catch (err) {
       throw new Error(ERRORS_MESSAGES.ipns)
     }


### PR DESCRIPTION
CLI is not able to deploy because IPFS key isn't being correctly parsed, this PR solves that.