### PR TITLE
feat: add "no-watch" functionality to preview

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -11,6 +11,7 @@ export interface IArguments {
   options: {
     port?: number
     browser?: boolean
+    watch?: boolean
   }
 }
 
@@ -20,11 +21,13 @@ export function start(vorpal: any) {
     .alias('start')
     .option('-p, --port <number>', 'parcel previewer server port (default is 2044).')
     .option('--no-browser', 'prevents the CLI from opening a new browser window.')
+    .option('--no-watch', 'prevents the CLI from watching filesystem changes.')
     .description('Starts local development server.')
     .action(
       wrapCommand(async (args: IArguments) => {
         const dcl = new Decentraland({
-          previewPort: args.options.port
+          previewPort: args.options.port,
+          watch: args.options.watch
         })
 
         Analytics.preview()

--- a/src/lib/Decentraland.ts
+++ b/src/lib/Decentraland.ts
@@ -15,6 +15,7 @@ export interface IDecentralandArguments {
   linkerPort?: number
   previewPort?: number
   isHttps?: boolean
+  watch?: boolean
 }
 
 export interface IAddressInfo {
@@ -117,7 +118,7 @@ export class Decentraland extends EventEmitter {
   async preview() {
     await this.project.validateExistingProject()
     await this.project.validateParcelOptions()
-    const preview = new Preview(await this.project.getDCLIgnore())
+    const preview = new Preview(await this.project.getDCLIgnore(), this.getWatch())
 
     events(preview, '*', this.pipeEvents.bind(this))
 
@@ -138,6 +139,10 @@ export class Decentraland extends EventEmitter {
       }
     }) as Promise<IAddressInfo>[]
     return Promise.all(info)
+  }
+
+  getWatch(): boolean {
+    return !!this.options.watch
   }
 
   async getProjectInfo(x: number, y: number) {


### PR DESCRIPTION
This feature allows to run `dcl start` on https://now.sh