### PR TITLE
feat: make `now` work in default scenes

### DIFF
--- a/src/samples/basic-static/package.json
+++ b/src/samples/basic-static/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "MIT",
   "scripts": {
-    "start": "dcl start"
+    "start": "dcl start --ci"
   },
   "devDependencies": {
     "decentraland-api": "latest"

--- a/src/samples/ts-dynamic/package.json
+++ b/src/samples/ts-dynamic/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "My new Decentraland project",
   "scripts": {
-    "start": "dcl start",
+    "start": "dcl start --ci",
     "build": "decentraland-compiler build.json",
     "watch": "decentraland-compiler build.json --watch"
   },

--- a/src/samples/ts-static/package.json
+++ b/src/samples/ts-static/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "My new Decentraland project",
   "scripts": {
-    "start": "dcl start",
+    "start": "dcl start --ci",
     "build": "decentraland-compiler build.json",
     "watch": "decentraland-compiler build.json --watch"
   },


### PR DESCRIPTION
Make `dcl init` provide you with a `now`-compatible project by default.