### PR TITLE
fix: fail and warn when user is using deprecated package 'metarverse-…

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -52,7 +52,7 @@ export function start(vorpal: any) {
         if (hasDeprecatedMetaverseApi) {
           fail(
             ErrorType.PREVIEW_ERROR,
-            `\n\n\n\n  ❗️ You've installed a deprecated package 'metaverse-api'. Please run:\n\n  npm rm metaverse-api && npm install decentraland-api@latest\n\n See more: https://docs.decentraland.org/releases/sdk/4.1.0/#migrate-a-scene-to-410\n`
+            `\n\n\n\n  ❗️ You've installed a deprecated package 'metaverse-api'. Please run:\n\n  npm rm metaverse-api && npm install decentraland-api@latest\n\n  See more: https://docs.decentraland.org/releases/sdk/4.1.0/#migrate-a-scene-to-410\n`
           )
         }
 

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -4,8 +4,7 @@ import {
   isOnline,
   getInstalledVersion,
   isDecentralandApiOutdated,
-  isDeprecatedApiInstalled,
-  findFilesWithDeprecatedApi
+  isDeprecatedApiInstalled
 } from '../utils/moduleHelpers'
 import { wrapCommand } from '../utils/wrapCommand'
 import { Analytics } from '../utils/analytics'
@@ -31,7 +30,6 @@ function getOrElse(value: any, def: any) {
 export function start(vorpal: any) {
   vorpal
     .command('start')
-    .alias('preview')
     .option('-p, --port <number>', 'parcel previewer server port (default is 2044).')
     .option('--no-browser', 'prevents the CLI from opening a new browser window.')
     .option('--no-watch', 'prevents the CLI from watching filesystem changes.')
@@ -54,15 +52,8 @@ export function start(vorpal: any) {
         if (hasDeprecatedMetaverseApi) {
           fail(
             ErrorType.PREVIEW_ERROR,
-            `\n\n\n\n  ❗️ You've installed a deprecated package 'metaverse-api'. Please run:\n\n  npm rm metaverse-api && npm install decentraland-api@latest\n\n\n`
+            `\n\n\n\n  ❗️ You've installed a deprecated package 'metaverse-api'. Please run:\n\n  npm rm metaverse-api && npm install decentraland-api@latest\n\n See more: https://docs.decentraland.org/releases/sdk/4.1.0/#migrate-a-scene-to-410\n`
           )
-        }
-
-        const getFilesWithDeprecatedApi = await findFilesWithDeprecatedApi()
-        if (getFilesWithDeprecatedApi) {
-          vorpal.log(error(`You're importing a deprecated package 'metaverse-api' on files:`))
-          getFilesWithDeprecatedApi.forEach(file => vorpal.log(error(`- ${file}`)))
-          fail(ErrorType.PREVIEW_ERROR, `Please fix those files and use 'decentraland-api' instead.`)
         }
 
         const sdkOutdated = await isDecentralandApiOutdated()

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import * as fs from 'fs-extra'
 
 /**

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -68,37 +68,3 @@ export async function isEmptyDirectory(dir: string = '.'): Promise<boolean> {
 export function getUserHome(): string {
   return process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME']
 }
-
-/**
- * Returns all the file names that has the provided string
- */
-export async function searchOnFiles(matcher: string, dir: string = '.', ext: string = '.tsx'): Promise<string[]> {
-  const files = await getFilesInDirectory(dir, ext)
-  return Promise.all(
-    files.filter(async file => {
-      const content = await fs.readFile(file, 'utf-8')
-      return content.indexOf(matcher) !== -1
-    })
-  )
-}
-
-async function getFilesInDirectory(dir: string, ext: string) {
-  let files = []
-  const filesFromDirectory = await fs.readdir(dir)
-
-  for (let file of filesFromDirectory) {
-    const filePath = path.join(dir, file)
-    const stat = await fs.lstat(filePath)
-
-    if (stat.isDirectory()) {
-      const nestedFiles = await getFilesInDirectory(filePath, ext)
-      files = files.concat(nestedFiles)
-    } else {
-      if (path.extname(file) === ext) {
-        files.push(filePath)
-      }
-    }
-  }
-
-  return files
-}

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as fs from 'fs-extra'
 
 /**
@@ -55,11 +56,7 @@ export async function readJSON<T>(path: string): Promise<T> {
 /**
  * Returns true if the directory is empty
  */
-export async function isEmptyDirectory(dir?: string): Promise<boolean> {
-  if (!dir) {
-    dir = '.'
-  }
-
+export async function isEmptyDirectory(dir: string = '.'): Promise<boolean> {
   const files = await fs.readdir(dir)
   return files.length === 0
 }
@@ -70,4 +67,38 @@ export async function isEmptyDirectory(dir?: string): Promise<boolean> {
  */
 export function getUserHome(): string {
   return process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME']
+}
+
+/**
+ * Returns all the file names that has the provided string
+ */
+export async function searchOnFiles(matcher: string, dir: string = '.', ext: string = '.tsx'): Promise<string[]> {
+  const files = await getFilesInDirectory(dir, ext)
+  return Promise.all(
+    files.filter(async file => {
+      const content = await fs.readFile(file, 'utf-8')
+      return content.indexOf(matcher) !== -1
+    })
+  )
+}
+
+async function getFilesInDirectory(dir: string, ext: string) {
+  let files = []
+  const filesFromDirectory = await fs.readdir(dir)
+
+  for (let file of filesFromDirectory) {
+    const filePath = path.join(dir, file)
+    const stat = await fs.lstat(filePath)
+
+    if (stat.isDirectory()) {
+      const nestedFiles = await getFilesInDirectory(filePath, ext)
+      files = files.concat(nestedFiles)
+    } else {
+      if (path.extname(file) === ext) {
+        files.push(filePath)
+      }
+    }
+  }
+
+  return files
 }

--- a/src/utils/moduleHelpers.ts
+++ b/src/utils/moduleHelpers.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as semver from 'semver'
 import { spawn } from 'child_process'
 import * as packageJson from 'package-json'
-import { readJSON, searchOnFiles } from '../utils/filesystem'
+import { readJSON } from '../utils/filesystem'
 import { getRootPath, getNodeModulesPath } from '../utils/project'
 import * as fetch from 'isomorphic-fetch'
 
@@ -64,10 +64,6 @@ export async function getInstalledVersion(name: string): Promise<string> {
 export async function isDeprecatedApiInstalled(): Promise<boolean> {
   const metaverseApi = await getInstalledVersion('metaverse-api')
   return !!metaverseApi
-}
-
-export async function findFilesWithDeprecatedApi(): Promise<string[]> {
-  return searchOnFiles('metaverse-api')
 }
 
 export async function isDecentralandApiOutdated(): Promise<boolean> {

--- a/src/utils/moduleHelpers.ts
+++ b/src/utils/moduleHelpers.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as semver from 'semver'
 import { spawn } from 'child_process'
 import * as packageJson from 'package-json'
-import { readJSON } from '../utils/filesystem'
+import { readJSON, searchOnFiles } from '../utils/filesystem'
 import { getRootPath, getNodeModulesPath } from '../utils/project'
 import * as fetch from 'isomorphic-fetch'
 
@@ -59,6 +59,15 @@ export async function getInstalledVersion(name: string): Promise<string> {
   }
 
   return decentralandApiPkg.version
+}
+
+export async function isDeprecatedApiInstalled(): Promise<boolean> {
+  const metaverseApi = await getInstalledVersion('metaverse-api')
+  return !!metaverseApi
+}
+
+export async function findFilesWithDeprecatedApi(): Promise<string[]> {
+  return searchOnFiles('metaverse-api')
 }
 
 export async function isDecentralandApiOutdated(): Promise<boolean> {


### PR DESCRIPTION
Metaverse-api installed on `package.json`:

![image](https://user-images.githubusercontent.com/14364153/44998605-52405f00-af8d-11e8-8263-fce69731c1f7.png)

Using `metaverse-api` on any `.tsx` files:
<img width="961" alt="screen shot 2018-09-03 at 15 25 04" src="https://user-images.githubusercontent.com/14364153/44998638-916eb000-af8d-11e8-81dd-377d9763c705.png">

This warning will be removed in version 1.5

https://decentraland.atlassian.net/browse/CLI-43