### PR TITLE
feat: support now and CIs by default

### DIFF
--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -11,8 +11,10 @@ import { Analytics } from '../utils/analytics'
 import { Decentraland } from '../lib/Decentraland'
 import { info, comment, loading, bold, error } from '../utils/logging'
 import { ErrorType, fail } from '../utils/errors'
+import { getOrElse } from '../utils'
 import opn = require('opn')
 import os = require('os')
+import { isEnvCi } from '../utils/env'
 
 export interface IArguments {
   options: {
@@ -21,10 +23,6 @@ export interface IArguments {
     ci?: boolean
     watch?: boolean
   }
-}
-
-function getOrElse(value: any, def: any) {
-  return value !== undefined ? value : def
 }
 
 export function start(vorpal: any) {
@@ -37,7 +35,7 @@ export function start(vorpal: any) {
     .description('Starts local development server.')
     .action(
       wrapCommand(async (args: IArguments) => {
-        const isCi = getOrElse(args.options.ci, false)
+        const isCi = getOrElse(args.options.ci, false) || isEnvCi()
 
         const shouldWatchFiles = getOrElse(args.options.watch, true) && !isCi
 

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -35,7 +35,7 @@ export function start(vorpal: any) {
     .description('Starts local development server.')
     .action(
       wrapCommand(async (args: IArguments) => {
-        const isCi = getOrElse(args.options.ci, false) || isEnvCi()
+        const isCi = getOrElse(args.options.ci, isEnvCi())
 
         const shouldWatchFiles = getOrElse(args.options.watch, true) && !isCi
 

--- a/src/samples/basic-static/package.json
+++ b/src/samples/basic-static/package.json
@@ -8,6 +8,7 @@
     "start": "dcl start"
   },
   "devDependencies": {
-    "decentraland-api": "latest"
+    "decentraland-api": "latest",
+    "decentraland": "latest"
   }
 }

--- a/src/samples/ts-dynamic/package.json
+++ b/src/samples/ts-dynamic/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "decentraland-api": "latest"
+    "decentraland-api": "latest",
+    "decentraland": "latest"
   }
 }

--- a/src/samples/ts-static/package.json
+++ b/src/samples/ts-static/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "decentraland-api": "latest"
+    "decentraland-api": "latest",
+    "decentraland": "latest"
   }
 }

--- a/src/samples/websockets/package.json
+++ b/src/samples/websockets/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "decentraland-api": "latest"
+    "decentraland-api": "latest",
+    "decentraland": "latest"
   }
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,10 @@
+import { getOrElse } from '.'
+
 /**
  * Check if CLI is used in development mode.
  */
 export const isDev: boolean = process.env.DCL_ENV === 'dev'
+
+export function isEnvCi(): boolean {
+  return getOrElse(process.env.NOW, false) || getOrElse(process.env.CI, false)
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export function getOrElse(value: any, def: any) {
+  return value !== undefined ? value : def
+}

--- a/src/utils/wrapCommand.ts
+++ b/src/utils/wrapCommand.ts
@@ -1,7 +1,7 @@
 import { exit, warning } from './logging'
 import { Analytics, finishPendingTracking } from './analytics'
 import { isDecentralandApiOutdated, isCLIOutdated } from './moduleHelpers'
-import { getOrElse } from './index'
+import { getOrElse } from '.'
 import { isEnvCi } from './env'
 
 type TargetFunction = (args: any, callback: () => void) => Promise<any>
@@ -21,7 +21,7 @@ export interface IArguments {
   }
 }
 
-export function isCi(args: IArguments) {
+function isCi(args: IArguments) {
   return getOrElse(args.options.ci, false) || isEnvCi()
 }
 

--- a/src/utils/wrapCommand.ts
+++ b/src/utils/wrapCommand.ts
@@ -1,6 +1,8 @@
 import { exit, warning } from './logging'
 import { Analytics, finishPendingTracking } from './analytics'
 import { isDecentralandApiOutdated, isCLIOutdated } from './moduleHelpers'
+import { getOrElse } from './index'
+import { isEnvCi } from './env'
 
 type TargetFunction = (args: any, callback: () => void) => Promise<any>
 type WrappedFunction = (this: any, args: any, callback: () => void) => void
@@ -19,8 +21,8 @@ export interface IArguments {
   }
 }
 
-function isCi(args: IArguments) {
-  return !!args.options.ci
+export function isCi(args: IArguments) {
+  return getOrElse(args.options.ci, false) || isEnvCi()
 }
 
 async function wrapper(fn: TargetFunction, ctx: any, args: IArguments): Promise<void> {

--- a/src/utils/wrapCommand.ts
+++ b/src/utils/wrapCommand.ts
@@ -22,7 +22,7 @@ export interface IArguments {
 }
 
 function isCi(args: IArguments) {
-  return getOrElse(args.options.ci, false) || isEnvCi()
+  return getOrElse(args.options.ci, isEnvCi())
 }
 
 async function wrapper(fn: TargetFunction, ctx: any, args: IArguments): Promise<void> {


### PR DESCRIPTION
Implements #216 

# What? <!-- what is this PR? -->
Reads environment variables NOW (injected by now.sh) and CI (injected by most of CI services) and if they are set on true the CLI will continue on `--ci` mode regardless of the flag is set or not.

# Why? <!-- Explain the reason -->
We want to be now-ready when making `dcl init` without extra steps such like modifying `npm start` script or running `npm install --save-dev decentraland` before deploying.
