### PR TITLE
refactor: let's have a single source of addresses and providers

### DIFF
--- a/linker-app/src/modules/config.ts
+++ b/linker-app/src/modules/config.ts
@@ -8,6 +8,7 @@ export const owner = document.currentScript.getAttribute('owner')
 export const baseParcel = JSON.parse(document.currentScript.getAttribute('base-parcel')) as Coords
 export const parcels = JSON.parse(document.currentScript.getAttribute('parcels')) as Coords[]
 export const ipfsKey = document.currentScript.getAttribute('ipfs-key')
+export const provider = document.currentScript.getAttribute('provider')
 
 export function isDevelopment(): boolean {
   return env === 'dev'

--- a/linker-app/src/sagas.ts
+++ b/linker-app/src/sagas.ts
@@ -4,11 +4,11 @@ import { createWalletSaga } from 'decentraland-dapps/dist/modules/wallet/sagas'
 import { transactionSaga } from 'decentraland-dapps/dist/modules/transaction/sagas'
 
 import { MANAToken, LANDRegistry } from './contracts'
-import { isDevelopment } from './modules/config'
+import { provider } from './modules/config'
 import { landSaga } from './modules/land/sagas'
 
 const walletSaga = createWalletSaga({
-  provider: isDevelopment() ? 'https://ropsten.infura.io' : 'https://mainnet.infura.io',
+  provider,
   contracts: [MANAToken, LANDRegistry],
   eth
 })

--- a/src/lib/Ethereum.ts
+++ b/src/lib/Ethereum.ts
@@ -27,17 +27,18 @@ export interface ILandData {
  * ethereum:get-ipns-success - Successfully fetched and parsed landData
  */
 export class Ethereum extends EventEmitter {
+  private static addresses: any
   private static contracts = new Map<string, Contract>()
 
   static async getContractAddresses(): Promise<any> {
-    if (this.contracts) {
-      return this.contracts
+    if (this.addresses) {
+      return this.addresses
     }
 
     try {
       const raw = await fetch('https://contracts.decentraland.org/addresses.json')
-      this.contracts = await raw.json()
-      return this.contracts
+      this.addresses = await raw.json()
+      return this.addresses
     } catch (error) {
       fail(
         ErrorType.ETHEREUM_ERROR,
@@ -47,7 +48,8 @@ export class Ethereum extends EventEmitter {
   }
 
   static async getContractAddress(name: string): Promise<string> {
-    return (await this.getContractAddresses()).data[isDev ? 'ropsten' : 'mainnet'][name]
+    const addresses = await this.getContractAddresses()
+    return addresses[isDev ? 'ropsten' : 'mainnet'][name]
   }
 
   static async getContract(name: string): Promise<Contract> {

--- a/src/lib/Ethereum.ts
+++ b/src/lib/Ethereum.ts
@@ -74,9 +74,9 @@ export class Ethereum extends EventEmitter {
   }
 
   async getLandOf(address: string): Promise<ICoords[]> {
+    const contract = await Ethereum.getContract('LANDProxy')
     let res
     try {
-      const contract = await Ethereum.getContract('LANDProxy')
       const [x, y] = await contract['landOf'](address.toUpperCase())
       res = x.map(($, i) => ({ x: $.toNumber(), y: y[i].toNumber() }))
     } catch (e) {

--- a/src/lib/LinkerAPI.ts
+++ b/src/lib/LinkerAPI.ts
@@ -7,6 +7,7 @@ import * as express from 'express'
 import * as portfinder from 'portfinder'
 
 import { Project } from './Project'
+import { getProvider } from '../utils/env'
 
 /**
  * Events emitted by this class:
@@ -94,7 +95,9 @@ export class LinkerAPI extends EventEmitter {
           <div id="main">
             <script src="linker.js" env=${process.env.DCL_ENV} mana-contract=${this.manaContract} land-contract=${
         this.landContract
-      } base-parcel=${JSON.stringify(baseParcel)} parcels=${JSON.stringify(parcels)} owner=${owner} ipfs-key=${ipfsKey}></script>
+      } base-parcel=${JSON.stringify(baseParcel)} parcels=${JSON.stringify(
+        parcels
+      )} owner=${owner} ipfs-key=${ipfsKey}> provider=${getProvider()}</script>
           </div>
         </body>
       `)

--- a/src/lib/LinkerAPI.ts
+++ b/src/lib/LinkerAPI.ts
@@ -97,7 +97,7 @@ export class LinkerAPI extends EventEmitter {
         this.landContract
       } base-parcel=${JSON.stringify(baseParcel)} parcels=${JSON.stringify(
         parcels
-      )} owner=${owner} ipfs-key=${ipfsKey}> provider=${getProvider()}</script>
+      )} owner=${owner} ipfs-key=${ipfsKey} provider=${getProvider()}></script>
           </div>
         </body>
       `)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -2,3 +2,7 @@
  * Check if CLI is used in development mode.
  */
 export const isDev: boolean = process.env.DCL_ENV === 'dev'
+
+export function getProvider() {
+  return isDev ? 'https://ropsten.infura.io/' : 'https://mainnet.infura.io/'
+}


### PR DESCRIPTION
# What? <!-- what is this PR? -->
We aren't having a single source of truth when we talk about contract addresses and providers, linker-app was using hardcoded infura same as CLI and some functions where fetching contract addresses from [contracts.decentraland.org/addresses.json](https://contracts.decentraland.org/addresses.json) but others have also hardcoded addresses

# Why? <!-- Explain the reason -->
Avoid a properties mess, prior env variables, otherwise fetch missing ones.
