### PR TITLE
test: check ownership on deploy

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -51,8 +51,8 @@ export function init(vorpal: any) {
             signalling: 'https://rendezvous.decentraland.org'
           },
           policy: {
-            fly: 'true',
-            voiceEnabled: 'true',
+            fly: true,
+            voiceEnabled: true,
             blacklist: [],
             teleportPosition: '0,0,0'
           },

--- a/test/e2e/cli/01.init.spec.ts
+++ b/test/e2e/cli/01.init.spec.ts
@@ -14,16 +14,10 @@ describe('init command', async () => {
         env: { DCL_ENV: 'dev' }
       })
         .when(/Send anonymous usage stats to Decentraland?/, () => Response.YES)
-        .when(/Scene title/, () => 'My test Scene\n')
-        .when(/Your ethereum address/, () => '0x\n')
-        .when(/Your name/, () => 'John Titor\n')
-        .when(/Your email/, () => 'john.titor@example.com\n')
-        .when(/Parcels comprising the scene/, () => '0,0\n')
-        .when(/Which scene template would you like to generate/, () => '4\n')
         .endWhen(/Installing dependencies/)
         .on('err', e => console.log(e))
         .on('end', async () => {
-          expect(await fs.pathExists(path.resolve(dirPath, 'scene.xml')), 'scene.xml should exist').to.be.true
+          expect(await fs.pathExists(path.resolve(dirPath, 'scene.tsx')), 'scene.tsx should exist').to.be.true
           expect(await fs.pathExists(path.resolve(dirPath, 'scene.json')), 'scene.json should exist').to.be.true
           expect(await fs.pathExists(path.resolve(dirPath, '.decentraland')), '.decentraland should exist').to.be.true
           expect(await fs.pathExists(path.resolve(dirPath, 'package.json')), 'package.json should exist').to.be.true
@@ -31,17 +25,18 @@ describe('init command', async () => {
           expect(await fs.pathExists(path.resolve(dirPath, 'node_modules')), 'node_modules should exist').to.be.false
           expect(await fs.pathExists(path.resolve(dirPath, '.dclignore')), '.dclignore shoudl exist').to.be.true
 
-          const sceneFile = await fs.readFile(path.resolve(dirPath, 'scene.json'))
+          const sceneFileJson = await fs.readFile(path.resolve(dirPath, 'scene.json'))
+          const sceneFile = JSON.parse(sceneFileJson.toString())
 
-          expect(JSON.parse(sceneFile.toString())).to.deep.equal({
+          const expected = {
             display: {
-              title: 'My test Scene'
+              title: sceneFile.display.title
             },
-            owner: '0x',
             contact: {
-              name: 'John Titor',
-              email: 'john.titor@example.com'
+              name: '',
+              email: ''
             },
+            owner: '',
             scene: {
               parcels: ['0,0'],
               base: '0,0'
@@ -56,9 +51,10 @@ describe('init command', async () => {
               blacklist: [],
               teleportPosition: '0,0,0'
             },
-            main: 'scene.xml'
-          })
+            main: 'scene.js'
+          }
 
+          expect(sceneFile).to.deep.equal(expected)
           done()
         })
     })

--- a/test/e2e/cli/02.deploy.spec.ts
+++ b/test/e2e/cli/02.deploy.spec.ts
@@ -12,12 +12,6 @@ describe('deploy command', async () => {
         workingDir: dirPath,
         env: { DCL_ENV: 'dev' }
       })
-        .when(/Scene title/, () => 'My test Scene\n')
-        .when(/Your ethereum address/, () => '0x\n')
-        .when(/Your name/, () => 'John Titor\n')
-        .when(/Your email/, () => 'john.titor@example.com\n')
-        .when(/Parcels comprising the scene/, () => '0,0\n')
-        .when(/Which scene template would you like to generate/, () => '4\n')
         .endWhen(/Installing dependencies/)
         .on('end', async () => {
           new Commando(`node ${path.resolve('bin', 'dcl')} deploy`, {

--- a/test/e2e/cli/02.deploy.spec.ts
+++ b/test/e2e/cli/02.deploy.spec.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import * as fs from 'fs-extra'
 import { expect } from 'chai'
 
 import { tmpTest } from '../../sandbox'
@@ -32,6 +33,91 @@ describe('deploy command', async () => {
             .when(/You are about to upload/, (msg: string) => {
               expect(msg.includes('You are about to upload 2 files'), 'expect file count to be correct').to.be.true
               return Response.NO
+            })
+            .on('end', async () => {
+              done()
+            })
+        })
+    })
+  }).timeout(5000)
+
+  it('should display an error message if owner attribute is missing', async () => {
+    await tmpTest(async (dirPath, done) => {
+      new Commando(`node ${path.resolve('bin', 'dcl')} init`, {
+        silent: true,
+        workingDir: dirPath,
+        env: { DCL_ENV: 'dev' }
+      })
+        .endWhen(/Installing dependencies/)
+        .on('end', async () => {
+          new Commando(`node ${path.resolve('bin', 'dcl')} deploy`, {
+            silent: true,
+            workingDir: dirPath,
+            env: { DCL_ENV: 'dev' }
+          })
+            .when(/\(.* bytes\)\n/, msg => {
+              const file = msg.trim().match(/(\w*\.\w*)/g)
+              expect(file.includes('scene.json'), 'expect scene.json to be listed').to.be.true
+              return null
+            })
+            .when(/\(.* bytes\)\n/, msg => {
+              const file = msg.trim().match(/(\w*\.\w*)/g)
+              expect(file.includes('scene.xml'), 'expect scene.xml to be listed').to.be.true
+              return null
+            })
+            .when(/You are about to upload/, (msg: string) => {
+              expect(msg.includes('You are about to upload 2 files'), 'expect file count to be correct').to.be.true
+              return Response.YES
+            })
+            .endWhen(/Missing owner attribute at scene.json/, (msg: string) => {
+              expect(
+                msg.includes('Missing owner attribute at scene.json. Owner attribute is required for deploying'),
+                'expect error message to be displayed'
+              ).to.be.true
+              return null
+            })
+            .on('end', async () => {
+              done()
+            })
+        })
+    })
+  }).timeout(5000)
+
+  it(`should display an error message if owner hasn't got deploying permission`, async () => {
+    await tmpTest(async (dirPath, done) => {
+      new Commando(`node ${path.resolve('bin', 'dcl')} init`, { silent: true, workingDir: dirPath, env: { DCL_ENV: 'dev' } })
+        .endWhen(/Installing dependencies/)
+        .on('end', async () => {
+          const sceneFileJson = await fs.readFile(path.resolve(dirPath, 'scene.json'))
+          const sceneFile = JSON.parse(sceneFileJson.toString())
+          sceneFile.owner = '0x8bed95d830475691c10281f1fea2c0a0fe51304b'
+          await fs.writeFile(path.resolve(dirPath, 'scene.json'), JSON.stringify(sceneFile))
+
+          new Commando(`node ${path.resolve('bin', 'dcl')} deploy`, {
+            silent: true,
+            workingDir: dirPath,
+            env: { DCL_ENV: 'dev' }
+          })
+            .when(/\(.* bytes\)\n/, msg => {
+              const file = msg.trim().match(/(\w*\.\w*)/g)
+              expect(file.includes('scene.json'), 'expect scene.json to be listed').to.be.true
+              return null
+            })
+            .when(/\(.* bytes\)\n/, msg => {
+              const file = msg.trim().match(/(\w*\.\w*)/g)
+              expect(file.includes('scene.xml'), 'expect scene.xml to be listed').to.be.true
+              return null
+            })
+            .when(/You are about to upload/, (msg: string) => {
+              expect(msg.includes('You are about to upload 2 files'), 'expect file count to be correct').to.be.true
+              return Response.YES
+            })
+            .endWhen(/Provided address/, (msg: string) => {
+              expect(
+                msg.includes('Provided address 0x8bed95d830475691c10281f1fea2c0a0fe51304b is not authorized to update LAND 0,0'),
+                'expect error message to be displayed'
+              ).to.be.true
+              return null
             })
             .on('end', async () => {
               done()

--- a/typings/dcl.d.ts
+++ b/typings/dcl.d.ts
@@ -21,8 +21,8 @@ declare namespace DCL {
 
   interface PolicySettings {
     contentRating?: string
-    fly: string
-    voiceEnabled: string
+    fly: boolean
+    voiceEnabled: boolean
     blacklist: Array<string>
     teleportPosition: string
   }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Check that we're checking ownership of parcels on deploy

# Why? <!-- Explain the reason -->
Because we are not asking setup questions anymore on init. We'll take `create-react-app` or `npm` approach and ask the less info as possible for init and start and all the things that need for deploying only at `dcl deploy`.
