### PR TITLE
Fixes #227

### DIFF
--- a/src/utils/moduleHelpers.ts
+++ b/src/utils/moduleHelpers.ts
@@ -101,7 +101,7 @@ export async function isCLIOutdated(): Promise<boolean> {
 
 export function isOnline(): Promise<boolean> {
   return new Promise(resolve => {
-    fetch('https://decentraland.org/')
+    fetch('https://decentraland.org/ping')
       .then(() => resolve(true))
       .catch(() => resolve(false))
     setTimeout(() => {


### PR DESCRIPTION

# What? 
Fetching ping endpoint instead of the entire landing

# Why? 
To avoid extra bandwidth consumption