### PR TITLE
fix: CLI not working because of decentraland-eth usage at Node.js

### DIFF
--- a/linker-app/src/modules/land/sagas.ts
+++ b/linker-app/src/modules/land/sagas.ts
@@ -51,11 +51,9 @@ function* handleConnectWalletSuccess(action: ConnectWalletSuccessAction) {
 function* handleSignContentRequest(action: SignContentRequestAction) {
   try {
     const hashToSign = action.payload
-    const signedMessage = yield call(
-      () => {
-        return eth.wallet.sign(hashToSign)
-      }
-    )
+    const signedMessage = yield call(() => {
+      return eth.wallet.sign(hashToSign)
+    })
     yield put(signContentSuccess(signedMessage))
   } catch (error) {
     yield put(signContentFailure(error.message))
@@ -63,12 +61,12 @@ function* handleSignContentRequest(action: SignContentRequestAction) {
 }
 
 function* handleSignContentSuccess(action: SignContentSuccessAction) {
+  const address = eth.wallet.getAccount()
+
   try {
-    yield call(
-      () => {
-        closeServer(true, action.payload)
-      }
-    )
+    yield call(() => {
+      closeServer(true, `{"signature":"${action.payload}","address":"${address}"}`)
+    })
   } catch (error) {
     yield put(signContentFailure(error.message))
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -55,7 +55,7 @@ export function deploy(vorpal: any) {
           const uploadMsg = loading(`Uploading content...`)
 
           dcl.on('upload:failed', (error: any) => {
-            uploadMsg.fail("Fail to upload content")
+            uploadMsg.fail('Fail to upload content')
             fail(ErrorType.DEPLOY_ERROR, `Unable ro upload content. ${error}`)
           })
 

--- a/test/unit/lib/decentraland.spec.ts
+++ b/test/unit/lib/decentraland.spec.ts
@@ -5,7 +5,7 @@ import { Decentraland } from '../../../src/lib/Decentraland'
 import { Ethereum } from '../../../src/lib/Ethereum'
 import { Project } from '../../../src/lib/Project'
 import * as ProjectUtils from '../../../src/utils/project'
-import { ContentService } from '../../../src/lib/content/ContentService';
+import { ContentService } from '../../../src/lib/content/ContentService'
 
 const ctx = sandbox.create()
 
@@ -35,7 +35,9 @@ describe('Decentraland', () => {
   let linkStub
   let uploadContentStub
 
-  const projectSignature = "0x9adcd58e1d65aeb9d92cb25f59a1f9d1c19d9935534c91e59057135b2ecf020e3e56476788cee00bd4a8aa62602af307851276ee4b97be4832fbc541b24f0d141c"
+  const address = '0x8Bed95D830475691C10281f1FeA2c0a0fE51304B'
+  const projectSignature =
+    '0x9adcd58e1d65aeb9d92cb25f59a1f9d1c19d9935534c91e59057135b2ecf020e3e56476788cee00bd4a8aa62602af307851276ee4b97be4832fbc541b24f0d141c'
 
   const addFilesResult = beforeEach(() => {
     // Ethereum stubs
@@ -47,16 +49,16 @@ describe('Decentraland', () => {
     ctx.stub(Project.prototype, 'validateExistingProject').callsFake(() => undefined)
     validateSceneOptionsStub = ctx.stub(Project.prototype, 'validateSceneOptions').callsFake(() => undefined)
     getParcelCoordinatesStub = ctx.stub(Project.prototype, 'getParcelCoordinates').callsFake(() => ({ x: 0, y: 0 }))
-    getOwnerStub = ctx.stub(Project.prototype, 'getOwner').callsFake(() => '0x8Bed95D830475691C10281f1FeA2c0a0fE51304B')
+    getOwnerStub = ctx.stub(Project.prototype, 'getOwner').callsFake(() => address)
     getEstateStub = ctx.stub(Project.prototype, 'getEstate').callsFake(() => undefined)
     getParcelsStub = ctx.stub(Project.prototype, 'getParcels').callsFake(() => ({ x: 0, y: 0 }))
     getFilesStub = ctx.stub(Project.prototype, 'getFiles').callsFake(() => [{ path: '/tmp/myFile.txt', content: null }])
 
     // ContentServicestubs
     uploadContentStub = ctx.stub(ContentService.prototype, 'uploadContent').callsFake(() => true)
-  
+
     // Decentraland stubs
-    linkStub = ctx.stub(Decentraland.prototype, 'link').callsFake(() => projectSignature)
+    linkStub = ctx.stub(Decentraland.prototype, 'link').callsFake(() => `{"signature":"${projectSignature}","address":"${address}"}`)
     // Utils stub
     var stub = ctx.stub(ProjectUtils, 'getRootPath').callsFake(() => '.')
   })


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Makes CLI work again because we now retrieve the public address from chrome instead of node process to after that upload it to the content server

# Why? <!-- Explain the reason -->
Because we don't want CLI users get mad 😡  
