### PR TITLE
chore: remove all estate deployment logic from project

### DIFF
--- a/linker-app/src/components/LinkerPage/LinkerPage.container.tsx
+++ b/linker-app/src/components/LinkerPage/LinkerPage.container.tsx
@@ -4,7 +4,7 @@ import { getData as getWallet, isConnected as isWalletConnected } from 'decentra
 
 import { RootState } from '../../types'
 import { LinkerPageProps } from './types'
-import { isLoading as isLandLoading, getData as getTarget, getError } from '../../modules/land/selectors'
+import { isLoading as isLandLoading, getData as getLand, getError } from '../../modules/land/selectors'
 import { signContentRequest } from '../../modules/land/actions'
 
 import LinkerPage from './LinkerPage'
@@ -14,11 +14,10 @@ const mapState = (state: RootState, ownProps: LinkerPageProps): LinkerPageProps 
 
   const isLoading = !isWalletConnected(state) || isLandLoading(state)
 
-  // Target could be either a single parcel or an estate
-  const target = getTarget(state)
+  const base = getLand(state)
   const error = getError(state)
 
-  return { ...ownProps, target, wallet, isLoading, error }
+  return { ...ownProps, base, wallet, isLoading, error }
 }
 
 const mapDispatch = (dispatch: Dispatch<AnyAction>): Partial<LinkerPageProps> => ({

--- a/linker-app/src/components/LinkerPage/LinkerPage.tsx
+++ b/linker-app/src/components/LinkerPage/LinkerPage.tsx
@@ -3,10 +3,10 @@ import { Address, Blockie, Header, Button, Loader } from 'decentraland-ui'
 import Navbar from 'decentraland-dapps/dist/containers/Navbar'
 
 import Error from '../Error'
-import { LinkerPageProps, LinkerPageState } from './types'
-import { baseParcel, estateId, isDevelopment, isEstate, rootCID } from '../../modules/config'
+import { LinkerPageProps } from './types'
+import { baseParcel, isDevelopment, rootCID } from '../../modules/config'
 
-export default class LinkScenePage extends React.PureComponent<LinkerPageProps, LinkerPageState> {
+export default class LinkScenePage extends React.PureComponent<LinkerPageProps, any> {
   constructor(props) {
     super(props)
   }
@@ -18,7 +18,7 @@ export default class LinkScenePage extends React.PureComponent<LinkerPageProps, 
   }
 
   render() {
-    const { wallet, isLoading, error, target } = this.props
+    const { wallet, isLoading, error, base } = this.props
     const { x, y } = baseParcel
     return (
       <div className="LinkScenePage">
@@ -29,7 +29,7 @@ export default class LinkScenePage extends React.PureComponent<LinkerPageProps, 
           <Error>{error}</Error>
         ) : (
           <React.Fragment>
-            <Header>Update {isEstate() ? 'Estate' : 'LAND'} data</Header>
+            <Header>Update LAND data</Header>
 
             <p>
               Using {wallet.type === 'node' ? 'MetaMask' : wallet.type} address: &nbsp;
@@ -40,25 +40,15 @@ export default class LinkScenePage extends React.PureComponent<LinkerPageProps, 
 
             <img
               className="map"
-              src={`https://api.decentraland.${isDevelopment() ? 'zone' : 'org'}/v1/${
-                isEstate() ? `estates/${estateId}` : `parcels/${x}/${y}`
-              }/map.png`}
+              src={`https://api.decentraland.${isDevelopment() ? 'zone' : 'org'}/v1/parcels/${x}/${y}/map.png`}
               alt={`Base parcel ${x},${y}`}
             />
 
             <p>
-              Updating <b>{target.name ? `"${target.name}"` : `${isEstate() ? 'Estate' : 'LAND'} without name`}</b>{' '}
-              {isEstate() ? (
-                <React.Fragment>
-                  with ID: <b>{estateId}</b>
-                </React.Fragment>
-              ) : (
-                <React.Fragment>
-                  at coordinates{' '}
-                  <b>
-                    {baseParcel.x}, {baseParcel.y}
-                  </b>
-                </React.Fragment>
+              Updating <b>{base.name ? `"${base.name}"` : `LAND without name`}</b> at coordinates{' '}
+              <b>
+                {x}, {y}
+              </b>
               )}
             </p>
 
@@ -73,7 +63,6 @@ export default class LinkScenePage extends React.PureComponent<LinkerPageProps, 
                 </Button>
               </div>
             </form>
-
           </React.Fragment>
         )}
         <style>{`

--- a/linker-app/src/components/LinkerPage/types.ts
+++ b/linker-app/src/components/LinkerPage/types.ts
@@ -1,26 +1,15 @@
 import { BaseWallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { Transaction } from 'decentraland-dapps/dist/modules/transaction/types'
 
-import { LANDMeta, Coords } from '../../modules/land/types'
+import { LANDMeta } from '../../modules/land/types'
 import { SignContentRequestAction } from '../../modules/land/actions'
 
 export interface LinkerPageProps {
   sceneOwner: string
-  target: LANDMeta
+  base: LANDMeta
   wallet: Partial<BaseWallet>
   transaction: Transaction
   isLoading: boolean
   error: string
   onSignContent: (cid: string) => SignContentRequestAction
-}
-
-export interface IOptions {
-  id: string
-  value: Coords
-  checked: boolean
-  base: boolean
-}
-
-export interface LinkerPageState {
-  options: IOptions[]
 }

--- a/linker-app/src/contracts.ts
+++ b/linker-app/src/contracts.ts
@@ -1,6 +1,5 @@
 import { contracts } from 'decentraland-eth'
-import { manaContract, landContract, estateContract } from './modules/config'
+import { manaContract, landContract } from './modules/config'
 
 export const MANAToken = new contracts.MANAToken(manaContract)
 export const LANDRegistry = new contracts.LANDRegistry(landContract)
-export const EstateRegistry = new contracts.EstateRegistry(estateContract)

--- a/linker-app/src/modules/config.ts
+++ b/linker-app/src/modules/config.ts
@@ -6,18 +6,11 @@ export const provider = document.currentScript.getAttribute('provider')
 
 export const manaContract = document.currentScript.getAttribute('mana-contract')
 export const landContract = document.currentScript.getAttribute('land-contract')
-export const estateContract = document.currentScript.getAttribute('estate-contract')
 
 export const owner = document.currentScript.getAttribute('owner')
 export const baseParcel = JSON.parse(document.currentScript.getAttribute('base-parcel')) as Coords
-export const parcels = JSON.parse(document.currentScript.getAttribute('parcels')) as Coords[]
-export const estateId = JSON.parse(document.currentScript.getAttribute('estate-id')) as number
 export const rootCID = document.currentScript.getAttribute('root-cid')
 
 export function isDevelopment(): boolean {
   return env === 'dev'
-}
-
-export function isEstate(): boolean {
-  return !!estateId
 }

--- a/linker-app/src/modules/land/sagas.ts
+++ b/linker-app/src/modules/land/sagas.ts
@@ -1,6 +1,6 @@
 import { call, put, takeLatest, takeEvery } from 'redux-saga/effects'
 import { contracts, eth } from 'decentraland-eth'
-import { CONNECT_WALLET_SUCCESS, ConnectWalletSuccessAction } from 'decentraland-dapps/dist/modules/wallet/actions'
+import { CONNECT_WALLET_SUCCESS } from 'decentraland-dapps/dist/modules/wallet/actions'
 
 import {
   FETCH_LAND_REQUEST,
@@ -15,8 +15,8 @@ import {
   SignContentSuccessAction,
   SIGN_CONTENT_SUCCESS
 } from './actions'
-import { baseParcel, isEstate, estateId } from '../config'
-import { LANDRegistry, EstateRegistry } from '../../contracts'
+import { baseParcel } from '../config'
+import { LANDRegistry } from '../../contracts'
 import { Coords } from './types'
 import { getEmptyLandData } from './utils'
 import { closeServer } from '../server/utils'
@@ -30,13 +30,8 @@ export function* landSaga() {
 
 function* handleFetchLandRequest(action: FetchLandRequestAction) {
   try {
-    let data
-    if (isEstate()) {
-      data = yield call(() => EstateRegistry['getMetadata'](action.payload))
-    } else {
-      const { x, y } = action.payload as Coords
-      data = yield call(() => LANDRegistry['landData'](x, y))
-    }
+    const { x, y } = action.payload as Coords
+    const data = yield call(() => LANDRegistry['landData'](x, y))
     const land = data ? contracts.LANDRegistry.decodeLandData(data) : getEmptyLandData()
     yield put(fetchLandSuccess(land))
   } catch (error) {
@@ -44,8 +39,8 @@ function* handleFetchLandRequest(action: FetchLandRequestAction) {
   }
 }
 
-function* handleConnectWalletSuccess(action: ConnectWalletSuccessAction) {
-  yield put(fetchLandRequest(isEstate() ? estateId : baseParcel))
+function* handleConnectWalletSuccess() {
+  yield put(fetchLandRequest(baseParcel))
 }
 
 function* handleSignContentRequest(action: SignContentRequestAction) {

--- a/linker-app/src/modules/land/utils.ts
+++ b/linker-app/src/modules/land/utils.ts
@@ -1,15 +1,4 @@
-import { Coords, LANDMeta } from './types'
-
-/**
- * Converts a Coords object to a string-based set of coordinates
- */
-export function getString({ x, y }: Coords): string {
-  return `${x},${y}`
-}
-
-export function isEqual(p1: Coords, p2: Coords): boolean {
-  return p1.x === p2.x && p1.y === p2.y
-}
+import { LANDMeta } from './types'
 
 export function getEmptyLandData(): LANDMeta {
   return {

--- a/linker-app/src/sagas.ts
+++ b/linker-app/src/sagas.ts
@@ -3,13 +3,13 @@ import { eth } from 'decentraland-eth'
 import { createWalletSaga } from 'decentraland-dapps/dist/modules/wallet/sagas'
 import { transactionSaga } from 'decentraland-dapps/dist/modules/transaction/sagas'
 
-import { MANAToken, LANDRegistry, EstateRegistry } from './contracts'
+import { MANAToken, LANDRegistry } from './contracts'
 import { provider } from './modules/config'
 import { landSaga } from './modules/land/sagas'
 
 const walletSaga = createWalletSaga({
   provider,
-  contracts: [MANAToken, LANDRegistry, EstateRegistry],
+  contracts: [MANAToken, LANDRegistry],
   eth
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -119,6 +119,12 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "@types/caseless": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.1.6",
@@ -174,9 +180,18 @@
     },
     "@types/flat": {
       "version": "0.0.28",
-      "resolved": "http://registry.npmjs.org/@types/flat/-/flat-0.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/@types/flat/-/flat-0.0.28.tgz",
       "integrity": "sha1-XHiBSdhabPj/X18ACs3ZEs3qQnQ=",
       "dev": true
+    },
+    "@types/form-data": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/fs-extra": {
       "version": "5.0.4",
@@ -222,7 +237,7 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "http://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
@@ -374,6 +389,18 @@
       "dev": true,
       "requires": {
         "@types/redux-storage": "*"
+      }
+    },
+    "@types/request": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
+      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
       }
     },
     "@types/rx": {
@@ -544,6 +571,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-Set5ZdrAaKI/qHdFlVMgm/GsAv/wkXhSTuZFkJ+JI7HK+wIkIlOaUXSXieIvJ0+OvGIqtREFoE+NHJtEq0gtEw==",
+      "dev": true
     },
     "@types/uuid": {
       "version": "3.4.4",
@@ -1368,13 +1401,13 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
@@ -1799,7 +1832,7 @@
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "dev": true,
       "requires": {
@@ -2101,7 +2134,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2153,7 +2186,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -3259,7 +3292,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -4275,7 +4308,7 @@
       "dependencies": {
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "requires": {
             "delegates": "^1.0.0",
@@ -4297,7 +4330,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -4310,7 +4343,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -4318,12 +4351,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "rc": {
@@ -4339,7 +4372,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
@@ -4351,7 +4384,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -5861,7 +5894,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -5903,7 +5936,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -6573,7 +6606,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "restore-cursor": {
@@ -8545,17 +8578,17 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "requires": {
             "string-width": "^2.1.1",
@@ -8565,7 +8598,7 @@
         },
         "color-convert": {
           "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "resolved": false,
           "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "requires": {
             "color-name": "^1.1.1"
@@ -8573,7 +8606,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
             "lru-cache": "^4.0.1",
@@ -8583,12 +8616,12 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "resolved": false,
           "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "resolved": false,
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -8602,7 +8635,7 @@
         },
         "make-dir": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
           "requires": {
             "pify": "^3.0.0"
@@ -8610,7 +8643,7 @@
         },
         "npm-package-arg": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
           "requires": {
             "hosted-git-info": "^2.6.0",
@@ -8621,7 +8654,7 @@
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "^0.7.0",
@@ -8631,7 +8664,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -8639,7 +8672,7 @@
         },
         "supports-color": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -8647,7 +8680,7 @@
         },
         "update-notifier": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
           "requires": {
             "boxen": "^1.2.1",
@@ -8664,12 +8697,12 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -8679,7 +8712,7 @@
         },
         "yargs": {
           "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "requires": {
             "cliui": "^4.0.0",
@@ -8698,14 +8731,14 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "resolved": false,
               "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
             "camelcase": "^4.1.0"
@@ -8863,7 +8896,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -9051,7 +9084,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -9742,7 +9775,7 @@
     },
     "react-redux": {
       "version": "5.0.7",
-      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
       "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
       "dev": true,
       "requires": {
@@ -10800,7 +10833,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -11139,7 +11172,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -11537,7 +11570,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
@@ -12290,7 +12323,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "restore-cursor": {
@@ -12654,7 +12687,7 @@
     },
     "yargs": {
       "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "dev": true,
       "requires": {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -53,10 +53,6 @@ export function info(vorpal: any) {
 
         if (!args.target) {
           await dcl.project.validateExistingProject()
-          const estateId = await dcl.project.getEstate()
-          if (estateId) {
-            return infoEstate(vorpal, dcl, estateId)
-          }
           const coords = await dcl.project.getParcelCoordinates()
           return infoParcel(vorpal, dcl, coords)
         }

--- a/src/lib/Decentraland.ts
+++ b/src/lib/Decentraland.ts
@@ -103,9 +103,8 @@ export class Decentraland extends EventEmitter {
     return new Promise<string>(async (resolve, reject) => {
       const manaContract = await Ethereum.getContractAddress('MANAToken')
       const landContract = await Ethereum.getContractAddress('LANDProxy')
-      const estateContract = await Ethereum.getContractAddress('EstateProxy')
 
-      const linker = new LinkerAPI(this.project, manaContract, landContract, estateContract)
+      const linker = new LinkerAPI(this.project, manaContract, landContract)
 
       events(linker, '*', this.pipeEvents.bind(this))
 
@@ -214,14 +213,7 @@ export class Decentraland extends EventEmitter {
 
   private async validateOwnership() {
     const owner = await this.project.getOwner()
-    const estate = await this.project.getEstate()
-    if (estate) {
-      await this.ethereum.validateAuthorizationOfEstate(owner, estate)
-      const parcels = await this.project.getParcels()
-      await this.ethereum.validateParcelsInEstate(estate, parcels)
-    } else {
-      const parcel = await this.project.getParcelCoordinates()
-      await this.ethereum.validateAuthorizationOfParcel(owner, parcel)
-    }
+    const parcel = await this.project.getParcelCoordinates()
+    await this.ethereum.validateAuthorizationOfParcel(owner, parcel)
   }
 }

--- a/src/lib/LinkerAPI.ts
+++ b/src/lib/LinkerAPI.ts
@@ -21,14 +21,12 @@ export class LinkerAPI extends EventEmitter {
   private app = express()
   private landContract: string
   private manaContract: string
-  private estateContract: string
 
-  constructor(project: Project, manaTokenContract: string, landRegistryContract: string, estateRegistryContract: string) {
+  constructor(project: Project, manaTokenContract: string, landRegistryContract: string) {
     super()
     this.project = project
     this.manaContract = manaTokenContract
     this.landContract = landRegistryContract
-    this.estateContract = estateRegistryContract
   }
 
   link(port: number, isHttps: boolean, rootCID: string) {
@@ -84,7 +82,6 @@ export class LinkerAPI extends EventEmitter {
       const baseParcel = await this.project.getParcelCoordinates()
       const parcels = await this.project.getParcels()
       const owner = await this.project.getOwner()
-      const estateId = await this.project.getEstate()
 
       res.write(`
         <head>
@@ -96,8 +93,8 @@ export class LinkerAPI extends EventEmitter {
         <body>
           <div id="main">
             <script src="linker.js" env=${process.env.DCL_ENV} mana-contract=${this.manaContract} land-contract=${this.landContract}
-              estate-contract=${this.estateContract} base-parcel=${JSON.stringify(baseParcel)} parcels=${JSON.stringify(parcels)}
-              estate-id=${estateId} owner=${owner} provider=${getProvider()} root-cid=${rootCID}></script>
+              base-parcel=${JSON.stringify(baseParcel)} parcels=${JSON.stringify(parcels)}
+              owner=${owner} provider=${getProvider()} root-cid=${rootCID}></script>
           </div>
         </body>
       `)

--- a/src/lib/Project.ts
+++ b/src/lib/Project.ts
@@ -2,14 +2,7 @@ import * as fs from 'fs-extra'
 import dockerNames = require('docker-names')
 import * as path from 'path'
 import { writeJSON, readJSON, isEmptyDirectory } from '../utils/filesystem'
-import {
-  getSceneFilePath,
-  SCENE_FILE,
-  getIgnoreFilePath,
-  DCLIGNORE_FILE,
-  PACKAGE_FILE,
-  getPackageFilePath
-} from '../utils/project'
+import { getSceneFilePath, SCENE_FILE, getIgnoreFilePath, DCLIGNORE_FILE, PACKAGE_FILE, getPackageFilePath } from '../utils/project'
 import ignore = require('ignore')
 import { fail, ErrorType } from '../utils/errors'
 import { inBounds, getBounds, getObject, areConnected, Coords } from '../utils/coordinateHelpers'
@@ -191,11 +184,6 @@ export class Project {
   async getParcels(): Promise<Coords[]> {
     const sceneFile = await this.getSceneFile()
     return sceneFile.scene.parcels.map(getObject)
-  }
-
-  async getEstate(): Promise<number> {
-    const sceneFile = await this.getSceneFile()
-    return (sceneFile.scene.estateId !== undefined) ? sceneFile.scene.estateId : null
   }
 
   /**

--- a/test/unit/lib/decentraland.spec.ts
+++ b/test/unit/lib/decentraland.spec.ts
@@ -24,10 +24,7 @@ const ctx = sandbox.create()
 
 describe('Decentraland', () => {
   let validateSceneOptionsStub
-  let getParcelCoordinatesStub
   let getOwnerStub
-  let getEstateStub
-  let validateAuthorizationOfEstateStub
   let getParcelsStub
   let validateParcelsInEstateStub
   let validateAuthorizationOfParcelStub
@@ -42,15 +39,13 @@ describe('Decentraland', () => {
   const addFilesResult = beforeEach(() => {
     // Ethereum stubs
     validateAuthorizationOfParcelStub = ctx.stub(Ethereum.prototype, 'validateAuthorizationOfParcel').callsFake(() => undefined)
-    validateAuthorizationOfEstateStub = ctx.stub(Ethereum.prototype, 'validateAuthorizationOfEstate').callsFake(() => undefined)
     validateParcelsInEstateStub = ctx.stub(Ethereum.prototype, 'validateParcelsInEstate').callsFake(() => ({ x: 0, y: 0 }))
 
     // Project stubs
     ctx.stub(Project.prototype, 'validateExistingProject').callsFake(() => undefined)
     validateSceneOptionsStub = ctx.stub(Project.prototype, 'validateSceneOptions').callsFake(() => undefined)
-    getParcelCoordinatesStub = ctx.stub(Project.prototype, 'getParcelCoordinates').callsFake(() => ({ x: 0, y: 0 }))
+    ctx.stub(Project.prototype, 'getParcelCoordinates').callsFake(() => ({ x: 0, y: 0 }))
     getOwnerStub = ctx.stub(Project.prototype, 'getOwner').callsFake(() => address)
-    getEstateStub = ctx.stub(Project.prototype, 'getEstate').callsFake(() => undefined)
     getParcelsStub = ctx.stub(Project.prototype, 'getParcels').callsFake(() => ({ x: 0, y: 0 }))
     getFilesStub = ctx.stub(Project.prototype, 'getFiles').callsFake(() => [{ path: '/tmp/myFile.txt', content: null }])
 
@@ -78,29 +73,8 @@ describe('Decentraland', () => {
       expect(getFilesStub.called, 'expect Project.getFiles() to be called').to.be.true
       expect(validateSceneOptionsStub.called, 'expect Project.validateParcelOptions() to be called').to.be.true
       expect(getOwnerStub.called, 'expect Project.getOwner() to be called').to.be.true
-      expect(getEstateStub.called, 'expect Project.getParcels() to be called').to.be.true
       expect(getParcelsStub.called, 'expect Project.getParcels() to be called').to.be.false
-      expect(validateAuthorizationOfEstateStub.called, 'expect Project.getParcels() to be called').to.be.false
       expect(validateParcelsInEstateStub.called, 'expect Project.getParcels() to be called').to.be.false
-      expect(linkStub.calledBefore(uploadContentStub), 'expect Decentraland.link() to be called').to.be.true
-      expect(uploadContentStub.called).to.be.true
-    })
-
-    it('should verify estate ownership', async () => {
-      getEstateStub.callsFake(() => 49)
-
-      const dcl = new Decentraland()
-      const files = await dcl.project.getFiles()
-      await dcl.deploy(files)
-
-      expect(validateAuthorizationOfParcelStub.called, 'expect Ethereum.validateAuthorization() to be called').to.be.false
-      expect(getFilesStub.called, 'expect Project.getFiles() to be called').to.be.true
-      expect(validateSceneOptionsStub.called, 'expect Project.validateParcelOptions() to be called').to.be.true
-      expect(getOwnerStub.called, 'expect Project.getOwner() to be called').to.be.true
-      expect(getEstateStub.called, 'expect Project.getParcels() to be called').to.be.true
-      expect(getParcelsStub.called, 'expect Project.getParcels() to be called').to.be.true
-      expect(validateAuthorizationOfEstateStub.called, 'expect Project.getParcels() to be called').to.be.true
-      expect(validateParcelsInEstateStub.called, 'expect Project.getParcels() to be called').to.be.true
       expect(linkStub.calledBefore(uploadContentStub), 'expect Decentraland.link() to be called').to.be.true
       expect(uploadContentStub.called).to.be.true
     })


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Remove estate deployment logic from the CLI and the Linker Dapp

# Why? <!-- Explain the reason -->
Estates are only being used as a shorthand or business logic for LAND trading only, it does nothing to do with scenes.