### PR TITLE
fix: make `dcl info` parcels of estates show real owners  

### DIFF
--- a/src/lib/API.ts
+++ b/src/lib/API.ts
@@ -1,7 +1,8 @@
-import { Coords } from '../utils/coordinateHelpers'
-import { fail, ErrorType } from '../utils/errors'
 import { LANDData } from './Ethereum'
 import { IEthereumDataProvider } from './IEthereumDataProvider'
+
+import { Coords } from '../utils/coordinateHelpers'
+import { fail, ErrorType } from '../utils/errors'
 import { filterAndFillEmpty } from '../utils/land'
 
 const dclApiUrl = 'https://api.decentraland.org/v1'
@@ -31,7 +32,7 @@ export class API implements IEthereumDataProvider {
       return
     }
 
-    return json.data.id
+    return json.data.estate_id
   }
 
   async getEstateData(estateId: number): Promise<LANDData> {

--- a/src/lib/Decentraland.ts
+++ b/src/lib/Decentraland.ts
@@ -158,20 +158,21 @@ export class Decentraland extends EventEmitter {
     return !!this.options.watch
   }
 
-  async getProjectInfo(x: number, y: number) {
-    const scene = await this.project.getSceneFile()
-    const land = await this.provider.getLandData({ x, y })
-    const owner = await this.provider.getLandOwner({ x, y })
-    return { scene, land: { ...land, owner } }
-  }
-
-  async getParcelInfo({ x, y }: Coords): Promise<ParcelMetadata> {
-    const [scene, land, owner] = await Promise.all([
-      this.contentService.getSceneData({ x: x, y: y }),
-      this.provider.getLandData({ x, y }),
-      this.provider.getLandOwner({ x, y })
+  async getParcelInfo(coords: Coords): Promise<ParcelMetadata> {
+    const [scene, land, blockchainOwner] = await Promise.all([
+      this.contentService.getSceneData(coords),
+      this.provider.getLandData(coords),
+      this.provider.getLandOwner(coords)
     ])
 
+    const estateProxyAddress = await Ethereum.getContractAddress('EstateProxy')
+
+    if (blockchainOwner !== estateProxyAddress) {
+      return { scene, land: { ...land, owner: blockchainOwner } }
+    }
+
+    const estateId = await this.provider.getEstateIdOfLand(coords)
+    const owner = await this.provider.getEstateOwner(estateId)
     return { scene, land: { ...land, owner } }
   }
 

--- a/src/lib/Decentraland.ts
+++ b/src/lib/Decentraland.ts
@@ -189,7 +189,7 @@ export class Decentraland extends EventEmitter {
 
   async getEstateOfParcel(coords: Coords): Promise<Estate> {
     const estateId = await this.provider.getEstateIdOfLand(coords)
-    if (!estateId) {
+    if (!estateId || estateId < 1) {
       return
     }
 

--- a/src/lib/Ethereum.ts
+++ b/src/lib/Ethereum.ts
@@ -6,6 +6,7 @@ import { RequestManager, ContractFactory, providers, Contract } from 'eth-connec
 import { isDev, getProvider } from '../utils/env'
 import { ErrorType, fail } from '../utils/errors'
 import { Coords, getObject } from '../utils/coordinateHelpers'
+import { filterAndFillEmpty } from '../utils/land'
 
 import { abi as manaAbi } from '../../abi/MANAToken.json'
 import { abi as landAbi } from '../../abi/LANDRegistry.json'
@@ -101,7 +102,7 @@ export class Ethereum extends EventEmitter implements IEthereumDataProvider {
     const contract = await Ethereum.getContract('LANDProxy')
     try {
       const landData = await contract['landData'](x, y)
-      return this.decodeLandData(landData)
+      return filterAndFillEmpty(this.decodeLandData(landData))
     } catch (e) {
       fail(ErrorType.ETHEREUM_ERROR, `Unable to fetch LAND data: ${e.message}`)
     }
@@ -111,7 +112,7 @@ export class Ethereum extends EventEmitter implements IEthereumDataProvider {
     const contract = await Ethereum.getContract('EstateProxy')
     try {
       const landData = await contract['getMetadata'](estateId)
-      return this.decodeLandData(landData)
+      return filterAndFillEmpty(this.decodeLandData(landData))
     } catch (e) {
       fail(ErrorType.ETHEREUM_ERROR, `Unable to fetch LAND data: ${e.message}`)
     }

--- a/src/utils/land.ts
+++ b/src/utils/land.ts
@@ -2,8 +2,8 @@ import { LANDData } from '../lib/Ethereum'
 
 export function filterAndFillEmpty(data: any, def: string = null): LANDData {
   if (!data) {
-    return data
+    return { name: def, description: def }
   }
 
-  return { name: data.name ? data.name : def, description: data.description ? data.description : def }
+  return { name: data.name || def, description: data.description || def }
 }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Makes the `dcl info` command for parcels of estates show real owners instead of estate registry + an estate preview of the parcel
