### PR TITLE
fix: change tsconfig of linker dapp to allow cli dist to expose

### DIFF
--- a/linker-app/tsconfig.json
+++ b/linker-app/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es2015",
     "diagnostics": true,
-    "outDir": "build",
+    "outDir": "../dist/linker-app",
     "baseUrl": ".",
     "moduleResolution": "node",
     "stripInternal": true,

--- a/src/lib/LinkerAPI.ts
+++ b/src/lib/LinkerAPI.ts
@@ -94,9 +94,7 @@ export class LinkerAPI extends EventEmitter {
 
   private setRoutes(rootCID: string) {
     this.app.get('/linker.js', (req, res) => {
-      res.sendFile(
-        path.resolve(__dirname, '../../linker-app/build/src/index.js')
-      )
+      res.sendFile(path.resolve(__dirname, './linker-app/src/index.js'))
     })
 
     this.app.get('/linker', async (req, res) => {


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Move linker build from linker src to dist cli

# Why? <!-- Explain the reason -->
So cli can still deploy