### PR TITLE
fix: do not throw error on no-content LANDs

### DIFF
--- a/src/lib/content/ContentService.ts
+++ b/src/lib/content/ContentService.ts
@@ -93,12 +93,16 @@ export class ContentService extends EventEmitter {
       coordinates
     )
 
-    const sceneFileCID = information.contents[SCENE_FILE]
-
-    if (sceneFileCID) {
-      return this.client.getContent(sceneFileCID)
+    if (!information) {
+      return null
     }
-    return null
+
+    const sceneFileCID = information.contents[SCENE_FILE]
+    if (!sceneFileCID) {
+      return null
+    }
+
+    return this.client.getContent(sceneFileCID)
   }
 
   private buildMetadata(


### PR DESCRIPTION
# What? <!-- what is this PR? -->
There is a non-handled error when no-content LANDs are being deployed or requested via `dcl info`

# Why? <!-- Explain the reason -->
The content service needs to handle this error and return null