### PR TITLE
feat: expose wallet, set a different working dir

### DIFF
--- a/src/lib/Decentraland.ts
+++ b/src/lib/Decentraland.ts
@@ -21,6 +21,7 @@ import { IEthereumDataProvider } from './IEthereumDataProvider'
 
 export type DecentralandArguments = {
   workingDir: string
+  wallet?: ethers.wallet
   linkerPort?: number
   previewPort?: number
   isHttps?: boolean
@@ -78,8 +79,10 @@ export class Decentraland extends EventEmitter {
     this.provider = this.options.blockchain ? this.ethereum : new API()
     this.contentService = new ContentService(new ContentClient(this.options.config.contentUrl))
 
-    if (process.env.DCL_PRIVATE_KEY) {
-      this.createWallet(process.env.DCL_PRIVATE_KEY)
+    if (args.wallet) {
+      this.wallet = args.wallet
+    } else if (process.env.DCL_PRIVATE_KEY) {
+      this.wallet = this.createWallet(process.env.DCL_PRIVATE_KEY)
     }
 
     // Pipe all events
@@ -289,7 +292,7 @@ export class Decentraland extends EventEmitter {
     this.emit(event, ...args)
   }
 
-  private createWallet(privateKey: string): void {
+  private createWallet(privateKey: string): ethers.wallet {
     let length = 64
 
     if (privateKey.startsWith('0x')) {
@@ -300,7 +303,7 @@ export class Decentraland extends EventEmitter {
       fail(ErrorType.DEPLOY_ERROR, 'Addresses should be 64 characters length.')
     }
 
-    this.wallet = new ethers.Wallet(privateKey)
+    return new ethers.Wallet(privateKey)
   }
 
   private getEpoch(): number {

--- a/src/lib/Decentraland.ts
+++ b/src/lib/Decentraland.ts
@@ -21,7 +21,7 @@ import { IEthereumDataProvider } from './IEthereumDataProvider'
 
 export type DecentralandArguments = {
   workingDir: string
-  wallet?: ethers.wallet
+  wallet?: ethers.Wallet
   linkerPort?: number
   previewPort?: number
   isHttps?: boolean
@@ -92,6 +92,12 @@ export class Decentraland extends EventEmitter {
 
   getWorkingDir(): string {
     return this.options.workingDir
+  }
+
+  updateWorkingDir(newWorkingDir: string)
+  {
+    this.options.workingDir = newWorkingDir;
+    this.project = new Project(this.options.workingDir);
   }
 
   async init(sceneMeta: SceneMetadata, boilerplateType: BoilerplateType, websocketServer?: string) {
@@ -292,7 +298,7 @@ export class Decentraland extends EventEmitter {
     this.emit(event, ...args)
   }
 
-  private createWallet(privateKey: string): ethers.wallet {
+  private createWallet(privateKey: string): ethers.Wallet {
     let length = 64
 
     if (privateKey.startsWith('0x')) {


### PR DESCRIPTION
This pull will add an optional option to Decentraland.ts allowing for a wallet instances to be passed in.
It will also allow for the working dir to be change by a function call.

I would like this merged so my repo Alonzo-Coeus/dcl-cli-api can hook into the cli and allow us to run the deploy command for multiple directories without resorting to the shell.