### PR TITLE
fix: do not explode on `dcl start` when .dclignore is missing

### DIFF
--- a/src/lib/Preview.ts
+++ b/src/lib/Preview.ts
@@ -48,7 +48,7 @@ export class Preview extends EventEmitter {
       }
     }
 
-    const watcher = new Watcher(this.dcl.getWorkingDir(), this.ignoredPaths || [])
+    const watcher = new Watcher(this.dcl.getWorkingDir(), this.ignoredPaths || '')
 
     watcher.onProcessingComplete.push(() => {
       this.wss.clients.forEach(client => {

--- a/src/lib/Preview.ts
+++ b/src/lib/Preview.ts
@@ -48,7 +48,7 @@ export class Preview extends EventEmitter {
       }
     }
 
-    const watcher = new Watcher(this.dcl.getWorkingDir(), this.ignoredPaths)
+    const watcher = new Watcher(this.dcl.getWorkingDir(), this.ignoredPaths || [])
 
     watcher.onProcessingComplete.push(() => {
       this.wss.clients.forEach(client => {


### PR DESCRIPTION
Fixes https://github.com/decentraland/cli/issues/433