### PR TITLE
feat: add mock scene endpoints

### DIFF
--- a/src/lib/Preview.ts
+++ b/src/lib/Preview.ts
@@ -133,13 +133,13 @@ export class Preview extends EventEmitter {
     })
 
     this.app.get('/scenes', async (_, res) => {
-      const mapping = watcher.getMappings()[0]
+      const mapping = watcher.getMappings()
       const { parcel_id, root_cid, publisher } = mapping
       return res.json({ data: [{ parcel_id, root_cid, publisher, scene_cid: '' }] })
     })
 
     this.app.get('/parcel_info', (_, res) => {
-      const mapping = watcher.getMappings()[0]
+      const mapping = watcher.getMappings()
       const { parcel_id, root_cid, publisher } = mapping
       return res.json({
         data: [

--- a/src/lib/Preview.ts
+++ b/src/lib/Preview.ts
@@ -128,8 +128,30 @@ export class Preview extends EventEmitter {
 
     this.app.use(nocache)
 
-    this.app.get('/mappings', (req, res) => {
+    this.app.get('/mappings', (_, res) => {
       res.json(watcher.getMappings())
+    })
+
+    this.app.get('/scenes', async (_, res) => {
+      const mapping = watcher.getMappings()[0]
+      const { parcel_id, root_cid, publisher } = mapping
+      return res.json({ data: [{ parcel_id, root_cid, publisher, scene_cid: '' }] })
+    })
+
+    this.app.get('/parcel_info', (_, res) => {
+      const mapping = watcher.getMappings()[0]
+      const { parcel_id, root_cid, publisher } = mapping
+      return res.json({
+        data: [
+          {
+            parcel_id,
+            root_cid,
+            publisher,
+            scene_cid: '',
+            content: mapping
+          }
+        ]
+      })
     })
 
     this.app.get('/scene.json', (_, res) => {


### PR DESCRIPTION
# What?
Add a `/scenes` and `/parcel_info` endpoints according to the latest https://github.com/decentraland/content-service changes

# Why?
So we can unblock https://github.com/decentraland/explorer/pull/224

Closes https://github.com/decentraland/cli/issues/440