### PR TITLE
chore: make decentraland-ui a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ scripts/*.js
 scripts/*.d.ts
 
 scripts/release.md
+src/css

--- a/package-lock.json
+++ b/package-lock.json
@@ -366,6 +366,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
       "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -608,6 +609,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-2.0.0.tgz",
       "integrity": "sha512-OLw7l+6sXFp7qJQGIpEktqhkQFOKsM8hto4RSkAkqs1NG/rG2Jb7ct8so7x4qaP3UNJEPUfnrFGuCCz3laLIBQ==",
+      "dev": true,
       "requires": {
         "exenv": "^1.2.2",
         "prop-types": "^15.6.2"
@@ -2785,7 +2787,8 @@
     "balloon-css": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/balloon-css/-/balloon-css-0.5.2.tgz",
-      "integrity": "sha512-zheJpzwyNrG4t39vusA67v3BYg1HTVXOF8cErPEHzWK88PEOFwgo6Ea9VHOgOWNMgeuOtFVtB73NE2NWl9uDyQ=="
+      "integrity": "sha512-zheJpzwyNrG4t39vusA67v3BYg1HTVXOF8cErPEHzWK88PEOFwgo6Ea9VHOgOWNMgeuOtFVtB73NE2NWl9uDyQ==",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -3586,7 +3589,8 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -4379,6 +4383,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-1.13.1.tgz",
       "integrity": "sha512-7KaSwIGlKhCiutbVWD3xX9OsX6C/F2+KLnhCs3iXA1H38CN+OMLh+H2CUXf781X7MdFZXzI8mAR8756TwvAW8Q==",
+      "dev": true,
       "requires": {
         "balloon-css": "^0.5.0",
         "ethereum-blockies": "^0.1.1",
@@ -5282,7 +5287,8 @@
     "ethereum-blockies": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ethereum-blockies/-/ethereum-blockies-0.1.1.tgz",
-      "integrity": "sha1-h5/pWd7vSSp6krQ9w0ro3C7lkfw="
+      "integrity": "sha1-h5/pWd7vSSp6krQ9w0ro3C7lkfw=",
+      "dev": true
     },
     "ethereum-common": {
       "version": "0.0.18",
@@ -5562,7 +5568,8 @@
     "exenv": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -8036,7 +8043,8 @@
     "jquery": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+      "dev": true
     },
     "js-sha3": {
       "version": "0.5.7",
@@ -8053,7 +8061,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -8202,7 +8211,8 @@
     "keyboard-key": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
+      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ==",
+      "dev": true
     },
     "keyv": {
       "version": "3.0.0",
@@ -8725,7 +8735,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -8871,6 +8882,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -9777,7 +9789,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -10137,6 +10150,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/parallax-js/-/parallax-js-3.1.0.tgz",
       "integrity": "sha512-UONoPKSQykeNvFcemDPxYYDU/T89LSffoaZAwOMhDp0ABhmFPwthgn2GrfB7An9Qo+8nPZIuQeZsh2pWn1qN3A==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "raf": "^3.3.0"
@@ -10298,7 +10312,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.0.7",
@@ -10490,6 +10505,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -10684,6 +10700,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -10782,7 +10799,8 @@
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
+      "dev": true
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -11023,7 +11041,8 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -11474,6 +11493,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
       "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
+      "dev": true,
       "requires": {
         "jquery": "x.*"
       }
@@ -11482,6 +11502,7 @@
       "version": "0.82.5",
       "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.82.5.tgz",
       "integrity": "sha512-Vi7gvo9EbRyNckYd6a/RaY5zk02SFCrRbU9ukdM/OOK8CH7sjIB4f78TkHTUar20Zsw2w6UnFzYWemSvIYfsOQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@semantic-ui-react/event-stack": "^2.0.0",
@@ -11668,7 +11689,8 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "linker:build": "decentraland-compiler build.linker.json",
     "linker:watch": "decentraland-compiler build.linker.json --watch",
     "scripts:build": "decentraland-compiler build.json",
-    "build": "npm run cli:build && npm run linker:build && npm run scripts:build",
+    "build": "npm run cli:build && npm run linker:build && npm run scripts:build && node ./postbuild",
+    "postinstall": "node ./postinstall",
     "lint": "tslint -e 'samples/**/*' -e '*.json' -c tslint.json 'src/**/*.ts'",
     "test": "FORCE_COLOR=1 ava",
     "test:dry": "FORCE_COLOR=1 ava --update-snapshots",
@@ -99,6 +100,7 @@
     "decentraland-dapps": "3.8.0",
     "decentraland-eth": "^8.6.0",
     "decentraland-rpc": "^3.1.6",
+    "decentraland-ui": "^1.13.1",
     "docker-names": "^1.0.3",
     "eth-connect": "^0.3.0",
     "ethers": "^4.0.12",
@@ -149,7 +151,6 @@
   },
   "dependencies": {
     "decentraland-ecs": "^6.4.9-20200527010700.commit-85d2fbc",
-    "decentraland-renderer": "^1.8.21483",
-    "decentraland-ui": "^1.13.1"
+    "decentraland-renderer": "^1.8.21483"
   }
 }

--- a/postbuild.js
+++ b/postbuild.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+const path = require('path')
+
+const cssPath = './src/css'
+const distPath = './dist/css'
+
+function copy(file) {
+  fs.copyFileSync(cssPath + '/' + file, path.resolve(distPath + '/' + path.basename(file)))
+}
+
+// make dir if it doesnt exist
+if (!fs.existsSync(distPath)) {
+  fs.mkdirSync(distPath)
+}
+
+// copy css files from src into dist
+copy('styles.css')
+copy('dark-theme.css')
+copy('logo.svg')

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+const path = require('path')
+
+const cssPath = './src/css'
+const uiPath = path.resolve(path.dirname(require.resolve('decentraland-ui')), '..')
+
+function copy(file) {
+  fs.copyFileSync(uiPath + '/' + file, path.resolve(cssPath + '/' + path.basename(file)))
+}
+
+// make dir if it doesnt exist
+if (!fs.existsSync(cssPath)) {
+  fs.mkdirSync(cssPath)
+}
+
+// copy css files from decentraland-ui into src
+copy('lib/styles.css')
+copy('lib/dark-theme.css')
+copy('static/logo.svg')

--- a/src/lib/LinkerAPI.ts
+++ b/src/lib/LinkerAPI.ts
@@ -17,9 +17,6 @@ export type LinkerResponse = {
   network: Network
 }
 
-// Path to the root folder of decentraland-ui. Wrapped in an eval to avoid webpack resolver.
-const uiPath = path.resolve(path.dirname(eval("require.resolve('decentraland-ui')")), '..') // tslint:disable-line
-
 /**
  * Events emitted by this class:
  *
@@ -124,17 +121,17 @@ export class LinkerAPI extends EventEmitter {
     })
 
     this.app.get('/css/styles.css', (_req, res) => {
-      const filePath = path.resolve(uiPath, './lib/styles.css')
+      const filePath = path.resolve(__dirname, './css/styles.css')
       res.sendFile(filePath)
     })
 
     this.app.get('/css/dark-theme.css', (_req, res) => {
-      const filePath = path.resolve(uiPath, './lib/dark-theme.css')
+      const filePath = path.resolve(__dirname, './css/dark-theme.css')
       res.sendFile(filePath)
     })
 
     this.app.get('/css/logo.svg', (_req, res) => {
-      const filePath = path.resolve(uiPath, './static/logo.svg')
+      const filePath = path.resolve(__dirname, './css/logo.svg')
       res.sendFile(filePath)
     })
 


### PR DESCRIPTION
Closes #508 

# What? <!-- what is this PR? -->

I moved `decentraland-ui` from `dependencies` to `devDependencies` so it doesn't get installed when installing the CLI. It still get's installed in for development, and I added a postinstall script that copies it's contents to the `src/css` directory where it is consumed by the `LinkerAPI.ts`. Finaly I added a `postbuild` that copies the files from `src/css` into `dist/css` so the CLI server can find them when installed from NPM.

# Why? <!-- Explain the reason -->

To get rid of the peer dependecy warnings that show in the console when a users installs the CLI.
