### PR TITLE
feat: including more files in .dclignore 

### DIFF
--- a/src/lib/Project.ts
+++ b/src/lib/Project.ts
@@ -229,7 +229,12 @@ export class Project {
       '*.ts',
       '*.tsx',
       'Dockerfile',
-      'dist'
+      'dist',
+      'README.md',
+      '*.blend',
+      '*.fbx',
+      '*.zip',
+      '*.rar',
     ].join('\n')
     await fs.outputFile(path.join(this.workingDir, DCLIGNORE_FILE), content)
     return content


### PR DESCRIPTION
When deploying a scene, all files that are not on the `.dclignore` file are uploaded to the content server. The problem is that in many cases, unwanted files end up being uploaded. This generates problems during deployment (since there is a limit on the upload size), and could also end up with unwanted files on all content servers.
