### PR TITLE
chore: add permissions to default scene json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -429,6 +429,216 @@
         "arrify": "^1.0.1"
       }
     },
+    "@ethersproject/abi": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.3.tgz",
+      "integrity": "sha512-fSSs4sgaf5R1955QSpYXW2YkrYBgyOSyENyyMEyJwxTsKJKQPaReTQXafyeRc8ZLi3/2uzeqakH09r0S1hlFng==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
+          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.3.tgz",
+      "integrity": "sha512-0dVq0IcJd6/qTjT+bhJw6ooJuCJDNWTL8SKRFBnqr4OgDW7p1AXX2l7lQd7vX9RpbnDzurSM+fTBKCVWjdm3Vw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/networks": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/transactions": "^5.0.3",
+        "@ethersproject/web": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.3.tgz",
+      "integrity": "sha512-uhHXqmcJcxWYD+hcvsp/pu8iSgqQzgSXHJtFGUYBBkWGpCp5kF95nSRlFnyVu9uAqZxwynBtOrPZBd1ACGBQBQ==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
     "@ethersproject/address": {
       "version": "5.0.0-beta.130",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.130.tgz",
@@ -441,6 +651,68 @@
         "@ethersproject/logger": ">=5.0.0-beta.129",
         "@ethersproject/rlp": ">=5.0.0-beta.126",
         "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.3.tgz",
+      "integrity": "sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        }
+      }
+    },
+    "@ethersproject/basex": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.3.tgz",
+      "integrity": "sha512-EvoER+OXsMAZlvbC0M/9UTxjvbBvTccYCI+uCAhXw+eS1+SUdD4v7ekAFpVX78rPLrLZB1vChKMm6vPHIu3WRA==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/properties": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
       }
     },
     "@ethersproject/bignumber": {
@@ -473,6 +745,368 @@
         "@ethersproject/bignumber": ">=5.0.0-beta.130"
       }
     },
+    "@ethersproject/contracts": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.3.tgz",
+      "integrity": "sha512-60H7UJx6qsp3JP5q3jFjzVNGUygRfz+XzfRwx/VeCKjHBUpFxPEIO2S30SMjYKPqw6JsgxbOjxFFZgOfQiNesw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.0.3",
+        "@ethersproject/abstract-provider": "^5.0.3",
+        "@ethersproject/abstract-signer": "^5.0.3",
+        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
+          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/hash": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.3.tgz",
+      "integrity": "sha512-KSnJyL0G9lxbOK0UPrUcaYTc/RidrX8c+kn7xnEpTmSGxqlndw4BzvQcRgYt31bOIwuFtwlWvOo6AN2tJgdQtA==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/strings": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.3.tgz",
+      "integrity": "sha512-+VQj0gRxfwRPHH7J32fTU8Ouk9CBFBIqvl937I0swO5PghNXBy/1U+o8gZMOitLIId1P3Wr6QcaDHkusi7OQXw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.3",
+        "@ethersproject/basex": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/pbkdf2": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4",
+        "@ethersproject/strings": "^5.0.3",
+        "@ethersproject/transactions": "^5.0.3",
+        "@ethersproject/wordlists": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.5.tgz",
+      "integrity": "sha512-g2kdOY5l+TDE5rIE9BLK+S7fiQMIIsM+KTxxVu4H2COROFwCSMeEb5uMCkccXc3iDX1sOBF653h8kTXCaFY03Q==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.3",
+        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/hdnode": "^5.0.3",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/pbkdf2": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/random": "^5.0.3",
+        "@ethersproject/strings": "^5.0.3",
+        "@ethersproject/transactions": "^5.0.3",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
+          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+          "dev": true
+        }
+      }
+    },
     "@ethersproject/keccak256": {
       "version": "5.0.0-beta.129",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.129.tgz",
@@ -489,6 +1123,50 @@
       "integrity": "sha512-mhclsjkFqah1Co594bTNYnJzYAbtp5lClUrFqhMAsRkqT08wMYxY+oB51JFigNBDV+hzjmfEURtFkQjEBRx9+g==",
       "dev": true
     },
+    "@ethersproject/networks": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.3.tgz",
+      "integrity": "sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/logger": "^5.0.5"
+      },
+      "dependencies": {
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        }
+      }
+    },
+    "@ethersproject/pbkdf2": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.3.tgz",
+      "integrity": "sha512-asc+YgJn7v7GKWYXGz3GM1d9XYI2HvdCw1cLEow2niEC9BfYA29rr1exz100zISk95GIU1YP2zV//zHsMtWE5Q==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/sha2": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        }
+      }
+    },
     "@ethersproject/properties": {
       "version": "5.0.0-beta.132",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.132.tgz",
@@ -496,6 +1174,154 @@
       "dev": true,
       "requires": {
         "@ethersproject/logger": ">=5.0.0-beta.129"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.6.tgz",
+      "integrity": "sha512-hY1mFtZvbzqckPxwyR989ujr+cEzsQQdx+DDkNI6E5wF8GiTETAUMl3SmxPzcPebSD++ZI4vKtYdcabsJF0yaA==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.3",
+        "@ethersproject/abstract-signer": "^5.0.3",
+        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/networks": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/random": "^5.0.3",
+        "@ethersproject/rlp": "^5.0.3",
+        "@ethersproject/strings": "^5.0.3",
+        "@ethersproject/transactions": "^5.0.3",
+        "@ethersproject/web": "^5.0.4",
+        "ws": "7.2.3"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
+          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "ws": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+          "dev": true
+        }
+      }
+    },
+    "@ethersproject/random": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.3.tgz",
+      "integrity": "sha512-pEhWRbgNeAY1oYk4nIsEtCTh9TtLsivIDbOX11n+DLZLYM3c8qCLxThXtsHwVsMs1JHClZr5auYC4YxtVVzO/A==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        }
       }
     },
     "@ethersproject/rlp": {
@@ -507,6 +1333,168 @@
         "@ethersproject/bytes": ">=5.0.0-beta.129"
       }
     },
+    "@ethersproject/sha2": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.3.tgz",
+      "integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "hash.js": "1.1.3"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
+      "integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "elliptic": "6.5.3"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@ethersproject/solidity": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.3.tgz",
+      "integrity": "sha512-a6ni4OIj1e+JrvDiuLVqygYmAh53Ljk5iErkjzPgFBY8dz9xQfDxhpASjOZY0lzCf+N125yeK9N7Vm3HI7OLzQ==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/strings": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
     "@ethersproject/strings": {
       "version": "5.0.0-beta.132",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.132.tgz",
@@ -516,6 +1504,385 @@
         "@ethersproject/bytes": ">=5.0.0-beta.129",
         "@ethersproject/constants": ">=5.0.0-beta.128",
         "@ethersproject/logger": ">=5.0.0-beta.129"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.3.tgz",
+      "integrity": "sha512-cqsAAFUQV6iWqfgLL7KCPNfd3pXJPDdYtE6QuBEAIpc7cgbJ7TIDCF/dN+1otfERHJIbjGSNrhh4axKRnSFswg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/rlp": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
+          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.3.tgz",
+      "integrity": "sha512-PyQ066mFczUy0CSJJrc/VK+1ATh1bsI8EkzAVT7GQ0IPJlNDcXnGNtlH5EQGHzuXA3GDQNV23poB0Cy/WDb2zg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        }
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.3.tgz",
+      "integrity": "sha512-Nouwfh1HlpxaeRRi4+UDVsfrd9fitBHUvw35bTMSwJLFsZTb9xPd0LGWdX4llwVlAP/CXb6qDc0zwYy6uLp7Lw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.3",
+        "@ethersproject/abstract-signer": "^5.0.3",
+        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/hdnode": "^5.0.3",
+        "@ethersproject/json-wallets": "^5.0.5",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/random": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.3",
+        "@ethersproject/wordlists": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
+          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.4.tgz",
+      "integrity": "sha512-1ZSbFGJo61huhDW5M8hqjP8zoCK6zZlu3jYAJrFKVNgBjEm1UYMY5fsoogYHWkLgCgBIf+M6yKzYdtAs4tol4Q==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/base64": "^5.0.3",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.3.tgz",
+      "integrity": "sha512-Asro9CcBJqxtMnmKrsg79GMmH02p0JmdOwhEdRHRbr51UMRqAfV5RjiidYk21aMsTflv4VY3HgFs6q6FtRJs+w==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.3"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
       }
     },
     "@ledgerhq/devices": {
@@ -1793,6 +3160,12 @@
         "async": "^2.4.0"
       }
     },
+    "async-iterator-to-array": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-array/-/async-iterator-to-array-0.0.1.tgz",
+      "integrity": "sha512-BH6nAEYCRjNh24ylW8juMrHq5k/wx2l3kLcFjVZQ3uNYNKHQmVb9UbXxDo9Z8YUjhCGTthUaR9hBf4aK+aHRQg==",
+      "dev": true
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -2921,12 +4294,6 @@
       "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
       "dev": true
     },
-    "blob-polyfill": {
-      "version": "4.0.20190430",
-      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-4.0.20190430.tgz",
-      "integrity": "sha512-REie9DM5XvHcqa9tuVT1QverzNpPbuRGffFGfwtHhZLHoToiAFP2YxHqVTQvET+UYnjRttGnlWag0+i3YgPKtw==",
-      "dev": true
-    },
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
@@ -3172,10 +4539,24 @@
       }
     },
     "bs58": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
-      "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40=",
-      "dev": true
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dev": true,
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "dev": true,
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
     },
     "buffer": {
       "version": "4.9.2",
@@ -3520,22 +4901,22 @@
       "dev": true
     },
     "cids": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
-      "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.5.0",
+        "buffer": "^5.6.0",
         "class-is": "^1.1.0",
-        "multibase": "~0.7.0",
+        "multibase": "^1.0.0",
         "multicodec": "^1.0.1",
-        "multihashes": "~0.4.17"
+        "multihashes": "^1.0.1"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -3707,16 +5088,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
-    },
-    "coinstring": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
-      "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
-      "dev": true,
-      "requires": {
-        "bs58": "^2.0.1",
-        "create-hash": "^1.1.1"
-      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -4072,16 +5443,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-blob": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cross-blob/-/cross-blob-1.2.2.tgz",
-      "integrity": "sha512-kePCp1l3Viow+ssFJOvYY26ugGL+5+kJGcy3R2PT/r8DsOVlYNMuR40ox2hlVABljwELAegOKL4S8BQnbR3DOw==",
-      "dev": true,
-      "requires": {
-        "blob-polyfill": "^4.0.20190430",
-        "fetch-blob": "^1.0.5"
-      }
-    },
     "cross-fetch": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
@@ -4196,34 +5557,29 @@
       }
     },
     "dcl-catalyst-client": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-1.2.5.tgz",
-      "integrity": "sha512-kDoHOIxSSfQ4s4JvD53IYJHqdZQX8+MwwLQQJlYUDHjCat88Y5Z+SIDNYmeNNqQadh85UFrVokktQ+vBkhN7wQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-2.1.4.tgz",
+      "integrity": "sha512-rXqYc5On04xLDekx7hhCp731zR4vh2QzKMtMUYwERvLYIYwDgg006F+ebLNuBY9vyM9TJAArh33G7IiIiA0NMw==",
       "dev": true,
       "requires": {
-        "@types/ms": "^0.7.31",
-        "abort-controller": "^3.0.0",
-        "cids": "^0.8.0",
-        "cross-blob": "^1.2.2",
-        "dcl-catalyst-commons": "^1.2.4",
-        "dcl-crypto": "^2.1.0",
-        "isomorphic-form-data": "^2.0.0",
-        "ms": "^2.1.2",
-        "multihashing-async": "^0.8.1"
+        "async-iterator-to-array": "0.0.1",
+        "dcl-catalyst-commons": "^1.4.2",
+        "dcl-crypto": "^2.2.0",
+        "isomorphic-form-data": "^2.0.0"
       }
     },
     "dcl-catalyst-commons": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-1.2.4.tgz",
-      "integrity": "sha512-JZmwovrghHddCgNE5zjNM57Hniu7o0KpOQSR4zeElYpIMGptYuIxLdLRwLGdMWOa7ZIcpvvF5T27mkeE/Gxt1Q==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-1.4.2.tgz",
+      "integrity": "sha512-Q3hS55ay1DpxYuY+gw1tv2OsIVe79M5OzdvrIBigTfjuYh6dOG3bgF/ABvMKeuiYTNQVi5ni1h9tUbN3pqZ1uA==",
       "dev": true,
       "requires": {
         "@types/isomorphic-fetch": "0.0.35",
         "@types/ms": "^0.7.31",
         "abort-controller": "^3.0.0",
         "cids": "^0.8.0",
+        "cross-fetch": "^3.0.5",
         "dcl-crypto": "^2.1.0",
-        "isomorphic-fetch": "^2.2.1",
         "ms": "^2.1.2",
         "multihashing-async": "^0.8.1"
       },
@@ -4233,13 +5589,22 @@
           "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
           "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
           "dev": true
+        },
+        "cross-fetch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
+          "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+          "dev": true,
+          "requires": {
+            "node-fetch": "2.6.0"
+          }
         }
       }
     },
     "dcl-crypto": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-crypto/-/dcl-crypto-2.1.0.tgz",
-      "integrity": "sha512-j3u27s/MpLPi5ZrG0xucjBL+aUkMHkrejkxrWkJ1n6/KkLhEXlnMTgKd5TjJPatTw7wgrCQuJLMTc8ohfOYW9w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dcl-crypto/-/dcl-crypto-2.3.0.tgz",
+      "integrity": "sha512-ypsd4XjSWaOj0DtESxpnY+YYQBy43c/uUrNRaVnWGiJehQc+3EC7nONnCy3p8XcLspGAwtes7nwWtRnsNKFvVQ==",
       "dev": true,
       "requires": {
         "eth-crypto": "^1.5.1",
@@ -4712,23 +6077,38 @@
       }
     },
     "eccrypto": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.3.tgz",
-      "integrity": "sha512-Xtyj039Xp2NDZwoe9IcD7pT1EwM4DILdxPCN2H7Rk1wgJNtTkFpk+cpX1QpuHTMaIhkatOBlGGKzGw/DUCDdqg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.5.tgz",
+      "integrity": "sha512-iGu2lqaSFEX7jmYQayOzSIB52PdXguUeR17V7ilfmd5nVdt683HvYB0DwuGK1Y3srNp/zl6D05JfEdFY+SC5MQ==",
       "dev": true,
       "requires": {
-        "acorn": "7.1.0",
-        "elliptic": "6.5.1",
+        "acorn": "7.1.1",
+        "elliptic": "6.5.3",
         "es6-promise": "4.2.8",
         "nan": "2.14.0",
         "secp256k1": "3.7.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
+        },
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
         }
       }
     },
@@ -5051,25 +6431,114 @@
       }
     },
     "eth-crypto": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-1.5.2.tgz",
-      "integrity": "sha512-xhu7rt3CdNKSQ5VcqiFwfp50YVtc1+VPiqYEfMa8Omx9rGn5QHdIjImSoEnlej3VbfHv25Kvpu6A5oPoSI6iUA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-1.7.0.tgz",
+      "integrity": "sha512-YLITUfai7j2ndv1/UuMrJHwr//HCuTMIG4QqwCZnf8Zui0fO0UdNnju8311Cf2ILmRhKsU9p/fJbzn/WNKo0Ow==",
       "dev": true,
       "requires": {
         "@types/bn.js": "4.11.6",
         "babel-runtime": "6.26.0",
-        "eccrypto": "1.1.3",
+        "eccrypto": "1.1.5",
         "eth-lib": "0.2.8",
         "ethereumjs-tx": "2.1.2",
         "ethereumjs-util": "6.2.0",
-        "ethers": "4.0.44",
-        "secp256k1": "3.8.0"
+        "ethers": "5.0.9",
+        "secp256k1": "4.0.2"
       },
       "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
+          "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
+          "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
+          "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.6"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
+          "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
         "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
@@ -5082,9 +6551,9 @@
           }
         },
         "ethereumjs-common": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
-          "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ==",
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+          "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
           "dev": true
         },
         "ethereumjs-tx": {
@@ -5110,35 +6579,62 @@
             "keccak": "^2.0.0",
             "rlp": "^2.2.3",
             "secp256k1": "^3.0.1"
+          },
+          "dependencies": {
+            "secp256k1": {
+              "version": "3.8.0",
+              "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+              "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+              "dev": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "bip66": "^1.1.5",
+                "bn.js": "^4.11.8",
+                "create-hash": "^1.2.0",
+                "drbg.js": "^1.0.1",
+                "elliptic": "^6.5.2",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.1.2"
+              }
+            }
           }
         },
         "ethers": {
-          "version": "4.0.44",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.44.tgz",
-          "integrity": "sha512-kCkMPkpYjBkxzqjcuYUfDY7VHDbf5EXnfRPUOazdqdf59SvXaT+w5lgauxLlk1UjxnAiNfeNS87rkIXnsTaM7Q==",
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.9.tgz",
+          "integrity": "sha512-jv2ULxAKRlJv0zrhpUvYcwwITFghoJOEhOqSJhLBT3TnZyF/lmAS3tC8nejIlwxzOJw7LCyde8U+BwTzZdFDrQ==",
           "dev": true,
           "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.5.2",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "hash.js": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-              "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.0"
-              }
-            }
+            "@ethersproject/abi": "^5.0.3",
+            "@ethersproject/abstract-provider": "^5.0.3",
+            "@ethersproject/abstract-signer": "^5.0.3",
+            "@ethersproject/address": "^5.0.3",
+            "@ethersproject/base64": "^5.0.3",
+            "@ethersproject/basex": "^5.0.3",
+            "@ethersproject/bignumber": "^5.0.6",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.3",
+            "@ethersproject/contracts": "^5.0.3",
+            "@ethersproject/hash": "^5.0.3",
+            "@ethersproject/hdnode": "^5.0.3",
+            "@ethersproject/json-wallets": "^5.0.5",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/networks": "^5.0.3",
+            "@ethersproject/pbkdf2": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/providers": "^5.0.6",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/sha2": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4",
+            "@ethersproject/solidity": "^5.0.3",
+            "@ethersproject/strings": "^5.0.3",
+            "@ethersproject/transactions": "^5.0.3",
+            "@ethersproject/units": "^5.0.3",
+            "@ethersproject/wallet": "^5.0.3",
+            "@ethersproject/web": "^5.0.4",
+            "@ethersproject/wordlists": "^5.0.3"
           }
         },
         "keccak": {
@@ -5154,38 +6650,21 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         },
         "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "dev": true,
           "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
             "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true
         }
       }
     },
@@ -5857,12 +7336,6 @@
       "requires": {
         "pend": "~1.2.0"
       }
-    },
-    "fetch-blob": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-1.0.5.tgz",
-      "integrity": "sha512-BIggzO037jmCrZmtgntzCD2ymEaWgw9OMJsfX7FOS1jXGqKW9FEhETJN8QK4KxzIJknRl3RQdyzz34of+NNTMQ==",
-      "dev": true
     },
     "fetch-ponyfill": {
       "version": "4.1.0",
@@ -7138,12 +8611,12 @@
       }
     },
     "hdkey": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.1.tgz",
-      "integrity": "sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.2.tgz",
+      "integrity": "sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==",
       "dev": true,
       "requires": {
-        "coinstring": "^2.0.0",
+        "bs58check": "^2.1.2",
         "safe-buffer": "^5.1.1",
         "secp256k1": "^3.0.1"
       }
@@ -9403,9 +10876,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.11.0.tgz",
-      "integrity": "sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
       "dev": true
     },
     "mock-require": {
@@ -9444,9 +10917,9 @@
       "dev": true
     },
     "multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
       "dev": true,
       "requires": {
         "base-x": "^3.0.8",
@@ -9454,9 +10927,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -9466,19 +10939,19 @@
       }
     },
     "multicodec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
-      "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
       "dev": true,
       "requires": {
-        "buffer": "^5.5.0",
+        "buffer": "^5.6.0",
         "varint": "^5.0.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -9488,20 +10961,20 @@
       }
     },
     "multihashes": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
-      "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
       "dev": true,
       "requires": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
+        "buffer": "^5.6.0",
+        "multibase": "^1.0.1",
         "varint": "^5.0.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -9511,23 +10984,23 @@
       }
     },
     "multihashing-async": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
-      "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+      "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
       "dev": true,
       "requires": {
         "blakejs": "^1.1.0",
         "buffer": "^5.4.3",
         "err-code": "^2.0.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.15",
+        "js-sha3": "^0.8.0",
+        "multihashes": "^1.0.1",
         "murmurhash3js-revisited": "^3.0.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -9535,9 +11008,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
           "dev": true
         },
         "js-sha3": {
@@ -9650,6 +11123,24 @@
           }
         }
       }
+    },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "dev": true
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -11703,9 +13194,9 @@
       "dev": true
     },
     "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
     },
     "simple-get": {
@@ -12326,9 +13817,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -14001,12 +15492,12 @@
       }
     },
     "xhr-request-promise": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
-      "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
       "dev": true,
       "requires": {
-        "xhr-request": "^1.0.1"
+        "xhr-request": "^1.1.0"
       }
     },
     "xhr2-cookies": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "chokidar": "^2.0.3",
     "cors": "^2.8.4",
     "cross-spawn": "^6.0.5",
-    "dcl-catalyst-client": "^1.2.5",
+    "dcl-catalyst-client": "^2.1.4",
     "dcl-tslint-config-standard": "^1.0.1",
     "decentraland-dapps": "3.8.0",
     "decentraland-eth": "^8.6.0",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -94,6 +94,7 @@ export async function main() {
       blacklist: [],
       teleportPosition: '0,0,0'
     },
+    requiredPermissions: [],
     main: 'scene.xml'
   }
 

--- a/src/sceneJson/types.ts
+++ b/src/sceneJson/types.ts
@@ -25,4 +25,5 @@ export type SceneMetadata = {
     blacklist: Array<string>
     teleportPosition: string
   }
+  requiredPermissions?: string[]
 }


### PR DESCRIPTION
This PR is doing two things:
1. We are adding the `requiredPermissions` property to the default `scene.json` file, so people know it exists
1. We are upgrading the version of `dcl-catalyst-client`. This new version calculates the timestamp of the deployment with an external API, so if the user that is currently deploying has a wrong time on their local machine, the deployment will still succeed.