### PR TITLE
fix: skip post install when not necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "linker:watch": "decentraland-compiler build.linker.json --watch",
     "scripts:build": "decentraland-compiler build.json",
     "build": "npm run cli:build && npm run linker:build && npm run scripts:build && node ./postbuild",
-    "postinstall": "node ./postinstall",
+    "postinstall": "node ./postinstall || echo 'skip postinstall...'",
     "lint": "tslint -e 'samples/**/*' -e '*.json' -c tslint.json 'src/**/*.ts'",
     "test": "FORCE_COLOR=1 ava",
     "test:dry": "FORCE_COLOR=1 ava --update-snapshots",


### PR DESCRIPTION
# What? <!-- what is this PR? -->

This PR prevents the postinstall script to throw

# Why? <!-- Explain the reason -->

The `postinstall` script is necessary for the development of the lib (see https://github.com/decentraland/cli/pull/509) but it's not necessary to run it when a user installs the lib using `npm install -g decentraland` since those files are already bundled by the `postbuild` script.