### PR TITLE
fix: avoid console error when installing the cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "linker:watch": "decentraland-compiler build.linker.json --watch",
     "scripts:build": "decentraland-compiler build.json",
     "build": "npm run cli:build && npm run linker:build && npm run scripts:build && node ./postbuild",
-    "postinstall": "node ./postinstall || echo 'skip postinstall...'",
+    "postinstall": "node ./postinstall 2> postinstall-error.log || echo 'skip postinstall...'",
     "lint": "tslint -e 'samples/**/*' -e '*.json' -c tslint.json 'src/**/*.ts'",
     "test": "FORCE_COLOR=1 ava",
     "test:dry": "FORCE_COLOR=1 ava --update-snapshots",


### PR DESCRIPTION
Right now, when installing or updating the cli, an error is show:
```
internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module '/Users/nchamo/repos/cli/postintall'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
```

The cli is still installed/updated, but the error is shown, causing confusion 