### PR TITLE
fix: enable web3 when exporting scenes

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -88,8 +88,16 @@ export async function main(): Promise<number> {
       path.resolve(exportDir, 'default-profile')
     ),
     fs.copy(
+      path.resolve(artifactPath, 'images/decentraland-connect'),
+      path.resolve(exportDir, 'images/decentraland-connect')
+    ),
+    fs.copy(
       path.resolve(artifactPath, 'images/progress-logo.png'),
       path.resolve(exportDir, 'images/progress-logo.png')
+    ),
+    fs.copy(
+      path.resolve(artifactPath, 'images/teleport.gif'),
+      path.resolve(exportDir, 'images/teleport.gif')
     )
   ])
 


### PR DESCRIPTION
During the last changes to the initial loading screen, the export page was not updated. Therefore, when exporting scenes, it wasn't possible to enable web3.

In order for it to work, we copied the current `preview.html`, and made a few little changes for it to be compatible with exporting scenes. Now, we need to copy the images that the preview displays.