### PR TITLE
fix: "dcl build" should always show the output of the build

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -30,7 +30,7 @@ export async function main(): Promise<number> {
   const workDir = process.cwd()
 
   if (await isTypescriptProject(workDir)) {
-    await buildTypescript(workDir, !process.env.DEBUG, !!args['--watch'])
+    await buildTypescript(workDir, false /* silent=false build should always inform errors */, !!args['--watch'])
   }
 
   return 0


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Should always show the output of the build. I had a scene not working and it was because it had errors in the code I was not seeing.

# Why? <!-- Explain the reason -->
Avoid headaches