### PR TITLE
fix: show error when scene project doesn't have tsconfig.json

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -146,6 +146,7 @@ export async function main(): Promise<number> {
     console.log(
       `Could not upload content. Please make sure that your project has a 'tsconfig.json' file.`
     )
+    return 1
   }
 
   return 0

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -142,6 +142,10 @@ export async function main(): Promise<number> {
       debug('\n' + error.stack)
       spinner.fail(`Could not upload content. ${error}`)
     }
+  } else {
+    console.log(
+      `Could not upload content. Please make sure that your project has a 'tsconfig.json' file.`
+    )
   }
 
   return 0


### PR DESCRIPTION
Previously, we failed silently when a project didn't have a `tsconfig.json`. Now we show the error message