### PR TITLE
chore: releasing new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "Decentraland CLI developer tool.",
   "bin": {
     "dcl": "dist/cli.js"


### PR DESCRIPTION
We are now releasing `3.4.6`