### PR TITLE
chore: release 3.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Decentraland CLI developer tool.",
   "bin": {
     "dcl": "dist/cli.js"


### PR DESCRIPTION
We have fixed (and confirmed the fixes) all problems in https://github.com/decentraland/cli/issues/533, so we can now release a new version of the cli