### PR TITLE
fix: avoid peer as default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -475,9 +475,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
@@ -486,7 +486,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -553,7 +552,6 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.10.tgz",
       "integrity": "sha512-cfC3lGgotfxX3SMri4+CisOPwignoj/QGHW9J29spC4R4Qqcnk/SYuVkPFBMdLbvBp3f/pGiVqPNwont0TSXhg==",
-      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.0.9",
         "@ethersproject/bignumber": "^5.0.13",
@@ -570,7 +568,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
           "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13",
             "@ethersproject/bytes": "^5.0.9",
@@ -583,7 +580,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -594,7 +590,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -603,7 +598,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13"
           }
@@ -612,7 +606,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
           "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "js-sha3": "0.5.7"
@@ -621,14 +614,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -637,7 +628,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
           "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8"
@@ -647,7 +637,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
           "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/constants": "^5.0.8",
@@ -660,7 +649,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
       "integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.0.13",
         "@ethersproject/bytes": "^5.0.9",
@@ -675,7 +663,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -686,7 +673,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -694,14 +680,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -712,7 +696,6 @@
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
       "integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.0.8",
         "@ethersproject/bignumber": "^5.0.13",
@@ -725,7 +708,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -736,7 +718,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -744,14 +725,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -776,7 +755,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
       "integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.9"
       },
@@ -785,7 +763,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -793,8 +770,7 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         }
       }
     },
@@ -802,7 +778,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.7.tgz",
       "integrity": "sha512-OsXnRsujGmYD9LYyJlX+cVe5KfwgLUbUJrJMWdzRWogrygXd5HvGd7ygX1AYjlu1z8W/+t2FoQnczDR/H2iBjA==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.9",
         "@ethersproject/properties": "^5.0.7"
@@ -812,7 +787,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -820,14 +794,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -898,7 +870,6 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.9.tgz",
       "integrity": "sha512-CCTxVeDh6sjdSEbjzONhtwPjECvaHE62oGkY8M7kP0CHmgLD2SEGel0HZib8e5oQKRKGly9AKcUFW4g3rQ0AQw==",
-      "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.0.10",
         "@ethersproject/abstract-provider": "^5.0.8",
@@ -915,7 +886,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
           "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13",
             "@ethersproject/bytes": "^5.0.9",
@@ -928,7 +898,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -939,7 +908,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -948,7 +916,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13"
           }
@@ -957,7 +924,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
           "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "js-sha3": "0.5.7"
@@ -966,14 +932,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -982,7 +946,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
           "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8"
@@ -994,7 +957,6 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
       "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.0.10",
         "@ethersproject/address": "^5.0.9",
@@ -1010,7 +972,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
           "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13",
             "@ethersproject/bytes": "^5.0.9",
@@ -1023,7 +984,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -1034,7 +994,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1043,7 +1002,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13"
           }
@@ -1052,7 +1010,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
           "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "js-sha3": "0.5.7"
@@ -1061,14 +1018,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1077,7 +1032,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
           "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8"
@@ -1087,12 +1041,135 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
           "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/constants": "^5.0.8",
             "@ethersproject/logger": "^5.0.8"
           }
+        }
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.10.tgz",
+      "integrity": "sha512-ZLwMtIcXK7xz2lSITDCl40W04CtRq4K9NwBxhCzdzPdaz6XnoJMwGz2YMVLg+8ksseq+RYtTwIIXtlK6vyvQyg==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/basex": "^5.0.7",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/pbkdf2": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/sha2": "^5.0.7",
+        "@ethersproject/signing-key": "^5.0.8",
+        "@ethersproject/strings": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/wordlists": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        }
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.12.tgz",
+      "integrity": "sha512-nac553zGZnOewpjlqbfy7WBl8m3y7qudzRsI2dCxrediYtPIVIs9f6Pbnou8vDmmp8X4/U4W788d+Ma88o+Gbg==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/hdnode": "^5.0.8",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/pbkdf2": "^5.0.7",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/random": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.9",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+          "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+          "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
         }
       }
     },
@@ -1116,7 +1193,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
       "integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.0.8"
       },
@@ -1124,9 +1200,17 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         }
+      }
+    },
+    "@ethersproject/pbkdf2": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.9.tgz",
+      "integrity": "sha512-ItE/wQ/WVw/ajEHPUVgfu0aEvksPgOQc+278bke8sGKnGO3ppjmqp0MHh17tHc1EBTzJbSms5aLIqc56qZ/oiA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/sha2": "^5.0.7"
       }
     },
     "@ethersproject/properties": {
@@ -1142,7 +1226,6 @@
       "version": "5.0.19",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.19.tgz",
       "integrity": "sha512-G+flo1jK1y/rvQy6b71+Nu7qOlkOKz+XqpgqFMZslkCzGuzQRmk9Qp7Ln4soK8RSyP1e5TCujaRf1H+EZahoaw==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.0.8",
         "@ethersproject/abstract-signer": "^5.0.10",
@@ -1169,7 +1252,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
           "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13",
             "@ethersproject/bytes": "^5.0.9",
@@ -1182,7 +1264,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -1193,7 +1274,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1202,7 +1282,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13"
           }
@@ -1211,7 +1290,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
           "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "js-sha3": "0.5.7"
@@ -1220,14 +1298,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1236,7 +1312,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
           "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8"
@@ -1246,7 +1321,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
           "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/constants": "^5.0.8",
@@ -1256,8 +1330,7 @@
         "ws": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
-          "dev": true
+          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
         }
       }
     },
@@ -1265,7 +1338,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
       "integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.9",
         "@ethersproject/logger": "^5.0.8"
@@ -1275,7 +1347,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1283,8 +1354,7 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         }
       }
     },
@@ -1301,7 +1371,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.7.tgz",
       "integrity": "sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.9",
         "@ethersproject/logger": "^5.0.8",
@@ -1312,7 +1381,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1320,14 +1388,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "hash.js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
@@ -1339,7 +1405,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
       "integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.9",
         "@ethersproject/logger": "^5.0.8",
@@ -1351,7 +1416,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1359,14 +1423,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1375,7 +1437,6 @@
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
           "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -1385,6 +1446,44 @@
             "minimalistic-assert": "^1.0.0",
             "minimalistic-crypto-utils": "^1.0.0"
           }
+        }
+      }
+    },
+    "@ethersproject/solidity": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.10.tgz",
+      "integrity": "sha512-8OG3HLqynWXDA6mVIHuHfF/ojTTwBahON7hc9GAKCqglzXCkVA3OpyxOJXPzjHClRIAUUiU7r9oy9Z/nsjtT/g==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/sha2": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+          "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
         }
       }
     },
@@ -1417,7 +1516,6 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
       "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
-      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.0.9",
         "@ethersproject/bignumber": "^5.0.13",
@@ -1434,7 +1532,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
           "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13",
             "@ethersproject/bytes": "^5.0.9",
@@ -1447,7 +1544,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -1458,7 +1554,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1467,7 +1562,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13"
           }
@@ -1476,7 +1570,6 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
           "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "js-sha3": "0.5.7"
@@ -1485,14 +1578,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1501,7 +1592,110 @@
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
           "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
-          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        }
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.11.tgz",
+      "integrity": "sha512-nOSPmcCWyB/dwoBRhhTtPGCsTbiXqmc7Q0Adwvafc432AC7hy3Fj3IFZtnSXsbtJ/GdHCIUIoA8gtvxSsFuBJg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/constants": "^5.0.8",
+        "@ethersproject/logger": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        }
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.12.tgz",
+      "integrity": "sha512-rboJebGf47/KPZrKZQdYg9BAYuXbc/OwcUyML1K1f2jnJeo1ObWV11U1PAWTjTbhhSy6/Fg+34GO2yMb5Dt1Rw==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.8",
+        "@ethersproject/abstract-signer": "^5.0.10",
+        "@ethersproject/address": "^5.0.9",
+        "@ethersproject/bignumber": "^5.0.13",
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/hash": "^5.0.10",
+        "@ethersproject/hdnode": "^5.0.8",
+        "@ethersproject/json-wallets": "^5.0.10",
+        "@ethersproject/keccak256": "^5.0.7",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/random": "^5.0.7",
+        "@ethersproject/signing-key": "^5.0.8",
+        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/wordlists": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+          "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+          "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8"
@@ -1513,7 +1707,6 @@
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
       "integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
-      "dev": true,
       "requires": {
         "@ethersproject/base64": "^5.0.7",
         "@ethersproject/bytes": "^5.0.9",
@@ -1526,7 +1719,6 @@
           "version": "5.0.13",
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -1537,7 +1729,6 @@
           "version": "5.0.9",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1546,7 +1737,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
-          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13"
           }
@@ -1554,14 +1744,12 @@
         "@ethersproject/logger": {
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
-          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
         },
         "@ethersproject/properties": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
-          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -1570,10 +1758,36 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
           "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
-          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        }
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.10.tgz",
+      "integrity": "sha512-jWsEm1iJzpg9SCXnNfFz+tcp4Ofzv0TJb6mj+soCNcar9GcT0yGz62ZsHC3pLQWaF4LkCzGwRJHJTXKjHQfG1A==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/hash": "^5.0.10",
+        "@ethersproject/logger": "^5.0.8",
+        "@ethersproject/properties": "^5.0.7",
+        "@ethersproject/strings": "^5.0.8"
+      },
+      "dependencies": {
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
         }
@@ -2062,7 +2276,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
       "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -2296,7 +2509,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
       "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -2365,12 +2577,12 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.2.tgz",
-      "integrity": "sha512-uiQQeu9tWl3f1+oK0yoAv9lt/KXO24iafxgQTkIYO/kitruILGx3uH+QtIAHqxFV+yIsdnJH+alel9KuE3J15Q==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.17.0.tgz",
+      "integrity": "sha512-/fKFDcoHg8oNan39IKFOb5WmV7oWhQe1K6CDaAVfJaNWEhmfqlA24g+u1lqU5bMH7zuNasfMId4LaYWC5ijRLw==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.15.2",
-        "@typescript-eslint/scope-manager": "4.15.2",
+        "@typescript-eslint/experimental-utils": "4.17.0",
+        "@typescript-eslint/scope-manager": "4.17.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -2404,9 +2616,9 @@
           }
         },
         "tsutils": {
-          "version": "3.20.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.20.0.tgz",
-          "integrity": "sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==",
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
           "requires": {
             "tslib": "^1.8.1"
           }
@@ -2419,14 +2631,14 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.2.tgz",
-      "integrity": "sha512-Fxoshw8+R5X3/Vmqwsjc8nRO/7iTysRtDqx6rlfLZ7HbT8TZhPeQqbPjTyk2RheH3L8afumecTQnUc9EeXxohQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.17.0.tgz",
+      "integrity": "sha512-ZR2NIUbnIBj+LGqCFGQ9yk2EBQrpVVFOh9/Kd0Lm6gLpSAcCuLLe5lUCibKGCqyH9HPwYC0GIJce2O1i8VYmWA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.15.2",
-        "@typescript-eslint/types": "4.15.2",
-        "@typescript-eslint/typescript-estree": "4.15.2",
+        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/typescript-estree": "4.17.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -2458,13 +2670,13 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.2.tgz",
-      "integrity": "sha512-SHeF8xbsC6z2FKXsaTb1tBCf0QZsjJ94H6Bo51Y1aVEZ4XAefaw5ZAilMoDPlGghe+qtq7XdTiDlGfVTOmvA+Q==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.17.0.tgz",
+      "integrity": "sha512-KYdksiZQ0N1t+6qpnl6JeK9ycCFprS9xBAiIrw4gSphqONt8wydBw4BXJi3C11ywZmyHulvMaLjWsxDjUSDwAw==",
       "requires": {
-        "@typescript-eslint/scope-manager": "4.15.2",
-        "@typescript-eslint/types": "4.15.2",
-        "@typescript-eslint/typescript-estree": "4.15.2",
+        "@typescript-eslint/scope-manager": "4.17.0",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/typescript-estree": "4.17.0",
         "debug": "^4.1.1"
       },
       "dependencies": {
@@ -2479,26 +2691,26 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.2.tgz",
-      "integrity": "sha512-Zm0tf/MSKuX6aeJmuXexgdVyxT9/oJJhaCkijv0DvJVT3ui4zY6XYd6iwIo/8GEZGy43cd7w1rFMiCLHbRzAPQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.17.0.tgz",
+      "integrity": "sha512-OJ+CeTliuW+UZ9qgULrnGpPQ1bhrZNFpfT/Bc0pzNeyZwMik7/ykJ0JHnQ7krHanFN9wcnPK89pwn84cRUmYjw==",
       "requires": {
-        "@typescript-eslint/types": "4.15.2",
-        "@typescript-eslint/visitor-keys": "4.15.2"
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/visitor-keys": "4.17.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.2.tgz",
-      "integrity": "sha512-r7lW7HFkAarfUylJ2tKndyO9njwSyoy6cpfDKWPX6/ctZA+QyaYscAHXVAfJqtnY6aaTwDYrOhp+ginlbc7HfQ=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-RN5z8qYpJ+kXwnLlyzZkiJwfW2AY458Bf8WqllkondQIcN2ZxQowAToGSd9BlAUZDB5Ea8I6mqL2quGYCLT+2g=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.2.tgz",
-      "integrity": "sha512-cGR8C2g5SPtHTQvAymEODeqx90pJHadWsgTtx6GbnTWKqsg7yp6Eaya9nFzUd4KrKhxdYTTFBiYeTPQaz/l8bw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.17.0.tgz",
+      "integrity": "sha512-lRhSFIZKUEPPWpWfwuZBH9trYIEJSI0vYsrxbvVvNyIUDoKWaklOAelsSkeh3E2VBSZiNe9BZ4E5tYBZbUczVQ==",
       "requires": {
-        "@typescript-eslint/types": "4.15.2",
-        "@typescript-eslint/visitor-keys": "4.15.2",
+        "@typescript-eslint/types": "4.17.0",
+        "@typescript-eslint/visitor-keys": "4.17.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -2572,9 +2784,9 @@
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
         "tsutils": {
-          "version": "3.20.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.20.0.tgz",
-          "integrity": "sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==",
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
           "requires": {
             "tslib": "^1.8.1"
           }
@@ -2587,11 +2799,11 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.2.tgz",
-      "integrity": "sha512-TME1VgSb7wTwgENN5KVj4Nqg25hP8DisXxNBojM4Nn31rYaNDIocNm5cmjOFfh42n7NVERxWrDFoETO/76ePyg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.17.0.tgz",
+      "integrity": "sha512-WfuMN8mm5SSqXuAr9NM+fItJ0SVVphobWYkWOwQ1odsfC014Vdxk/92t4JwS1Q6fCA/ABfCKpa3AVtpUKTNKGQ==",
       "requires": {
-        "@typescript-eslint/types": "4.15.2",
+        "@typescript-eslint/types": "4.17.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -3744,6 +3956,12 @@
         "async": "^2.4.0"
       }
     },
+    "async-iterator-to-array": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-array/-/async-iterator-to-array-0.0.1.tgz",
+      "integrity": "sha512-BH6nAEYCRjNh24ylW8juMrHq5k/wx2l3kLcFjVZQ3uNYNKHQmVb9UbXxDo9Z8YUjhCGTthUaR9hBf4aK+aHRQg==",
+      "dev": true
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -4817,8 +5035,7 @@
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "better-sqlite3": {
       "version": "7.1.2",
@@ -4965,12 +5182,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
       "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-    },
-    "blob-polyfill": {
-      "version": "4.0.20190430",
-      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-4.0.20190430.tgz",
-      "integrity": "sha512-REie9DM5XvHcqa9tuVT1QverzNpPbuRGffFGfwtHhZLHoToiAFP2YxHqVTQvET+UYnjRttGnlWag0+i3YgPKtw==",
-      "dev": true
     },
     "blob-to-buffer": {
       "version": "1.2.9",
@@ -5221,7 +5432,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "dev": true,
       "requires": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -5232,7 +5442,6 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
           "requires": {
             "base-x": "^3.0.2"
           }
@@ -5615,24 +5824,24 @@
       "dev": true
     },
     "cids": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
-      "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
       "requires": {
-        "buffer": "^5.5.0",
+        "buffer": "^5.6.0",
         "class-is": "^1.1.0",
-        "multibase": "~0.7.0",
+        "multibase": "^1.0.0",
         "multicodec": "^1.0.1",
-        "multihashes": "~0.4.17"
+        "multihashes": "^1.0.1"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         }
       }
@@ -6178,16 +6387,6 @@
         "warning": "^4.0.3"
       }
     },
-    "cross-blob": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cross-blob/-/cross-blob-1.2.2.tgz",
-      "integrity": "sha512-kePCp1l3Viow+ssFJOvYY26ugGL+5+kJGcy3R2PT/r8DsOVlYNMuR40ox2hlVABljwELAegOKL4S8BQnbR3DOw==",
-      "dev": true,
-      "requires": {
-        "blob-polyfill": "^4.0.20190430",
-        "fetch-blob": "^1.0.5"
-      }
-    },
     "cross-fetch": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
@@ -6420,60 +6619,21 @@
       }
     },
     "dcl-catalyst-client": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-1.2.5.tgz",
-      "integrity": "sha512-kDoHOIxSSfQ4s4JvD53IYJHqdZQX8+MwwLQQJlYUDHjCat88Y5Z+SIDNYmeNNqQadh85UFrVokktQ+vBkhN7wQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-4.0.0.tgz",
+      "integrity": "sha512-h1ddfGGoWLfCLaleoh+6rE2hYwH6risi/YIWTVe6WHGb/DdhuX3ddEb2Dg+Y9HDRNThDBJISMVm7SFQ3ynbSRg==",
       "dev": true,
       "requires": {
-        "@types/ms": "^0.7.31",
-        "abort-controller": "^3.0.0",
-        "cids": "^0.8.0",
-        "cross-blob": "^1.2.2",
-        "dcl-catalyst-commons": "^1.2.4",
-        "dcl-crypto": "^2.1.0",
-        "isomorphic-form-data": "^2.0.0",
-        "ms": "^2.1.2",
-        "multihashing-async": "^0.8.1"
-      },
-      "dependencies": {
-        "@types/isomorphic-fetch": {
-          "version": "0.0.35",
-          "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
-          "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
-          "dev": true
-        },
-        "cross-fetch": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-          "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-          "dev": true,
-          "requires": {
-            "node-fetch": "2.6.1"
-          }
-        },
-        "dcl-catalyst-commons": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-1.7.1.tgz",
-          "integrity": "sha512-GzOeM0S7Vq5prWzmEts1vQWePxfNi1dsVblcDmBT/SNmrI1s9cBrOVB4vNo87KdWO1bXyRZXxzq2iw4utQnuig==",
-          "dev": true,
-          "requires": {
-            "@types/isomorphic-fetch": "0.0.35",
-            "@types/ms": "^0.7.31",
-            "abort-controller": "^3.0.0",
-            "blob-to-buffer": "^1.2.9",
-            "cids": "^0.8.0",
-            "cross-fetch": "^3.0.5",
-            "dcl-crypto": "^2.1.0",
-            "ms": "^2.1.2",
-            "multihashing-async": "^0.8.1"
-          }
-        }
+        "async-iterator-to-array": "0.0.1",
+        "dcl-catalyst-commons": "^3.0.0",
+        "dcl-crypto": "^2.2.0",
+        "isomorphic-form-data": "git+https://github.com/decentraland/isomorphic-form-data.git#3409301b9e0348dc30da63955fa9fdb3ac46ac3e"
       }
     },
     "dcl-catalyst-commons": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-2.1.0.tgz",
-      "integrity": "sha512-zbPndghPml/XhHEpSzOUDy0xmJGSE5bqeCjRfd7TAbaxsB8SyuAGjb093HLuVyGGCcVluAMhMMDKjr+dVZG9Uw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-3.0.0.tgz",
+      "integrity": "sha512-EjjeecUUejnc1Qo68sqxUgXn4QCMtU5Cb69zuwwQ7M7s28HByWL+ETthB9Sio8TcSzLdb3PDga+Op6vFU8TJMA==",
       "requires": {
         "@types/isomorphic-fetch": "0.0.35",
         "@types/ms": "^0.7.31",
@@ -6513,9 +6673,9 @@
       }
     },
     "dcl-crypto": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-crypto/-/dcl-crypto-2.1.0.tgz",
-      "integrity": "sha512-j3u27s/MpLPi5ZrG0xucjBL+aUkMHkrejkxrWkJ1n6/KkLhEXlnMTgKd5TjJPatTw7wgrCQuJLMTc8ohfOYW9w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dcl-crypto/-/dcl-crypto-2.3.0.tgz",
+      "integrity": "sha512-ypsd4XjSWaOj0DtESxpnY+YYQBy43c/uUrNRaVnWGiJehQc+3EC7nONnCy3p8XcLspGAwtes7nwWtRnsNKFvVQ==",
       "requires": {
         "eth-crypto": "^1.5.1",
         "web3x": "^4.0.6"
@@ -7136,9 +7296,9 @@
       }
     },
     "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -7207,21 +7367,35 @@
       }
     },
     "eccrypto": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.3.tgz",
-      "integrity": "sha512-Xtyj039Xp2NDZwoe9IcD7pT1EwM4DILdxPCN2H7Rk1wgJNtTkFpk+cpX1QpuHTMaIhkatOBlGGKzGw/DUCDdqg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.5.tgz",
+      "integrity": "sha512-iGu2lqaSFEX7jmYQayOzSIB52PdXguUeR17V7ilfmd5nVdt683HvYB0DwuGK1Y3srNp/zl6D05JfEdFY+SC5MQ==",
       "requires": {
-        "acorn": "7.1.0",
-        "elliptic": "6.5.1",
+        "acorn": "7.1.1",
+        "elliptic": "6.5.3",
         "es6-promise": "4.2.8",
         "nan": "2.14.0",
         "secp256k1": "3.7.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+        },
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
         }
       }
     },
@@ -7429,12 +7603,12 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -7447,7 +7621,7 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -7481,9 +7655,9 @@
           }
         },
         "@babel/highlight": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
             "chalk": "^2.0.0",
@@ -7598,9 +7772,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -7890,38 +8064,93 @@
       }
     },
     "eth-crypto": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-1.5.2.tgz",
-      "integrity": "sha512-xhu7rt3CdNKSQ5VcqiFwfp50YVtc1+VPiqYEfMa8Omx9rGn5QHdIjImSoEnlej3VbfHv25Kvpu6A5oPoSI6iUA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-1.8.0.tgz",
+      "integrity": "sha512-q6P4Mg7S03NvlZDBMmnA3xJ8IgTbkPJ8jpf7wt7kmdlTDzUl8N8xm4ObJD8e7zYfPkf0cypLC4RorWwLKNJrGg==",
       "requires": {
         "@types/bn.js": "4.11.6",
         "babel-runtime": "6.26.0",
-        "eccrypto": "1.1.3",
+        "eccrypto": "1.1.5",
         "eth-lib": "0.2.8",
         "ethereumjs-tx": "2.1.2",
-        "ethereumjs-util": "6.2.0",
-        "ethers": "4.0.44",
-        "secp256k1": "3.8.0"
+        "ethereumjs-util": "7.0.5",
+        "ethers": "5.0.13",
+        "secp256k1": "4.0.2"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+        "@ethersproject/address": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.11.tgz",
+          "integrity": "sha512-Et4GBdD8/tsBGjCEOKee9upN29qjL5kbRcmJifb4Penmiuh9GARXL2/xpXvEp5EW+EIW/rfCHFJrkYBgoQFQBw==",
           "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
           }
         },
-        "ethereumjs-common": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
-          "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
+        "@ethersproject/bignumber": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.15.tgz",
+          "integrity": "sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
+          "integrity": "sha512-zhdUTj6RGtCJSgU+bDrWF6cGbvW453LoIC1DSNWrTlXzC7WuH4a+EiPrgc7/kNoRxerKuA/cxYlI8GwNtVtDlw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.10.tgz",
+          "integrity": "sha512-0y2T2NqykDrbPM3Zw9RSbPkDOxwChAL8detXaom76CfYoGxsOnRP/zTX8OUAV+x9LdwzgbWvWmeXrc0M7SuDZw=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.9.tgz",
+          "integrity": "sha512-ZCjzbHYTw+rF1Pn8FDCEmx3gQttwIHcm/6Xee8g/M3Ga3SfW4tccNMbs5zqnBH0E4RoOPaeNgyg1O68TaF0tlg==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.9.tgz",
+          "integrity": "sha512-ns1U7ZMVeruUW6JXc4om+1w3w4ynHN/0fpwmeNTsAjwGKoF8SAUgue6ylKpHKWSti2idx7jDxbn8hNNFHk67CA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
+          }
+        },
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
         },
         "ethereumjs-tx": {
           "version": "2.1.2",
@@ -7930,89 +8159,105 @@
           "requires": {
             "ethereumjs-common": "^1.5.0",
             "ethereumjs-util": "^6.0.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-          "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "0.1.6",
-            "keccak": "^2.0.0",
-            "rlp": "^2.2.3",
-            "secp256k1": "^3.0.1"
-          }
-        },
-        "ethers": {
-          "version": "4.0.44",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.44.tgz",
-          "integrity": "sha512-kCkMPkpYjBkxzqjcuYUfDY7VHDbf5EXnfRPUOazdqdf59SvXaT+w5lgauxLlk1UjxnAiNfeNS87rkIXnsTaM7Q==",
-          "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.5.2",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
           },
           "dependencies": {
-            "hash.js": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-              "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+            "ethereumjs-util": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
               "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.0"
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "^2.2.3"
               }
             }
           }
         },
-        "keccak": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-          "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+        "ethereumjs-util": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.5.tgz",
+          "integrity": "sha512-gLLZVXYUHR6pamO3h/+M1jzKz7qE20PKFyFKtq1PrIHA6wcLI96mDz96EMkkhXfrpk30rhpkw0iRnzxKhqaIdQ==",
           "requires": {
-            "bindings": "^1.5.0",
-            "inherits": "^2.0.4",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.2.0"
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            },
+            "rlp": {
+              "version": "2.2.6",
+              "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+              "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+              "requires": {
+                "bn.js": "^4.11.1"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.12.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                  "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+                }
+              }
+            }
           }
         },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        "ethers": {
+          "version": "5.0.13",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.13.tgz",
+          "integrity": "sha512-xtSVE6r3ltLZ2EHtzA0rd1s2TQaLTC11qhSG+iYhOgno+lhyIXffBC8CzLkQEp51+GlRTn9/xCjly6JCn5qwMA==",
+          "requires": {
+            "@ethersproject/abi": "^5.0.5",
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/base64": "^5.0.3",
+            "@ethersproject/basex": "^5.0.3",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/contracts": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/hdnode": "^5.0.4",
+            "@ethersproject/json-wallets": "^5.0.6",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/networks": "^5.0.3",
+            "@ethersproject/pbkdf2": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/providers": "^5.0.8",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/sha2": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4",
+            "@ethersproject/solidity": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/units": "^5.0.4",
+            "@ethersproject/wallet": "^5.0.4",
+            "@ethersproject/web": "^5.0.6",
+            "@ethersproject/wordlists": "^5.0.4"
+          }
         },
         "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
             "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -8187,7 +8432,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dev": true,
       "requires": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -8210,7 +8454,6 @@
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
           "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -8225,7 +8468,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
           "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-          "dev": true,
           "requires": {
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
@@ -8234,14 +8476,12 @@
         "scrypt-js": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-          "dev": true
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
         },
         "secp256k1": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
           "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-          "dev": true,
           "requires": {
             "elliptic": "^6.5.2",
             "node-addon-api": "^2.0.0",
@@ -8326,8 +8566,7 @@
     "ethereumjs-common": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
-      "dev": true
+      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -8881,9 +9120,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -8934,9 +9173,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
-      "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -8949,12 +9188,6 @@
       "requires": {
         "pend": "~1.2.0"
       }
-    },
-    "fetch-blob": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-1.0.5.tgz",
-      "integrity": "sha512-BIggzO037jmCrZmtgntzCD2ymEaWgw9OMJsfX7FOS1jXGqKW9FEhETJN8QK4KxzIJknRl3RQdyzz34of+NNTMQ==",
-      "dev": true
     },
     "fetch-ponyfill": {
       "version": "4.1.0",
@@ -10102,12 +10335,12 @@
       }
     },
     "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "process": "^0.11.10"
       }
     },
     "global-dirs": {
@@ -11146,9 +11379,8 @@
       }
     },
     "isomorphic-form-data": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
-      "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
+      "version": "git+https://github.com/decentraland/isomorphic-form-data.git#3409301b9e0348dc30da63955fa9fdb3ac46ac3e",
+      "from": "git+https://github.com/decentraland/isomorphic-form-data.git#3409301b9e0348dc30da63955fa9fdb3ac46ac3e",
       "dev": true,
       "requires": {
         "form-data": "^2.3.2"
@@ -12698,92 +12930,92 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
       "requires": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         }
       }
     },
     "multicodec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.1.tgz",
-      "integrity": "sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
       "requires": {
-        "buffer": "^5.5.0",
+        "buffer": "^5.6.0",
         "varint": "^5.0.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         }
       }
     },
     "multihashes": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
-      "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
       "requires": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
+        "buffer": "^5.6.0",
+        "multibase": "^1.0.1",
         "varint": "^5.0.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         }
       }
     },
     "multihashing-async": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
-      "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+      "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
       "requires": {
         "blakejs": "^1.1.0",
         "buffer": "^5.4.3",
         "err-code": "^2.0.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.15",
+        "js-sha3": "^0.8.0",
+        "multihashes": "^1.0.1",
         "murmurhash3js-revisited": "^3.0.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -12920,8 +13152,7 @@
     "node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-      "dev": true
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -12931,8 +13162,7 @@
     "node-gyp-build": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-      "dev": true
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -13931,9 +14161,9 @@
       "dev": true
     },
     "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -15099,7 +15329,8 @@
     "scrypt-js": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+      "dev": true
     },
     "secp256k1": {
       "version": "3.7.1",
@@ -16092,9 +16323,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
-          "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz",
+          "integrity": "sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -16159,9 +16390,9 @@
           }
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -17495,9 +17726,9 @@
       }
     },
     "varint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "vary": {
       "version": "1.1.2",
@@ -18256,6 +18487,22 @@
         "is-function": "^1.0.1",
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "global": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+          "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          }
+        },
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        }
       }
     },
     "xhr-request": {
@@ -18292,7 +18539,8 @@
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "Decentraland CLI developer tool.",
   "bin": {
     "dcl": "dist/cli.js"
@@ -98,7 +98,7 @@
     "cors": "^2.8.4",
     "cross-spawn": "^6.0.5",
     "css-loader": "^5.0.1",
-    "dcl-catalyst-client": "^1.2.5",
+    "dcl-catalyst-client": "^4.0.0",
     "dcl-tslint-config-standard": "^1.0.1",
     "decentraland-dapps": "^8.1.0",
     "decentraland-eth": "^8.6.0",
@@ -156,9 +156,10 @@
   "dependencies": {
     "@ethersproject/bytes": "^5.0.9",
     "@ethersproject/strings": "^5.0.8",
-    "dcl-catalyst-commons": "^2.1.0",
+    "dcl-catalyst-commons": "^3.0.0",
     "dcl-node-runtime": "^1.0.0",
     "decentraland-ecs": "^6.4.9-20200527010700.commit-85d2fbc",
-    "decentraland-renderer": "^1.8.21483"
+    "decentraland-renderer": "^1.8.21483",
+    "global": "^4.4.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,11 @@ module.exports = {
     new webpack.BannerPlugin({
       banner: '#!/usr/bin/env node',
       raw: true
-    })
+    }),
+    new webpack.ProvidePlugin({
+      window: 'global/window',
+   }),
+
   ],
   // external dependencies
   externals: ['aws-sdk', 'electron', 'dcl-node-runtime'],


### PR DESCRIPTION
Prior to this change, the CLI would use peer.decentraland.org as default, when deploying a new scene.

The problem is that this caused a really big single point of failure.

Now, the CLI will choose a random catalyst that is approved by the DAO