### PR TITLE
fix: avoid errors with 0 value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Decentraland CLI developer tool.",
   "bin": {
     "dcl": "dist/cli.js"

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -79,8 +79,10 @@ export function formatList(
         return buf.concat(separator, formatList(list, options, level + 1, 'array'))
       } else if (typeof item === 'object') {
         return buf.concat(separator, formatDictionary(item, options, level + 1, 'array'))
-      } else if (item) {
+      } else if (item !== undefined) {
         return buf.concat(separator, JSON.stringify(item))
+      } else {
+        return buf
       }
     }, '')
   } else {


### PR DESCRIPTION
Fixes https://github.com/decentraland/cli/issues/533

**Context:**
`dcl info` can show information about a specific parcel. It prints on the console some information regarding the scene's metadata.

The problem was that a specific scene had a `0` set as a spawn point. So the code would not enter the `if (item)` part, and the accumulator in the reduce would be undefined (since there was no else). In the next iteration, it would fail