### PR TITLE
feat: load setupProxy.js in preview

### DIFF
--- a/src/lib/Preview.ts
+++ b/src/lib/Preview.ts
@@ -17,6 +17,8 @@ import * as proto from './proto/broker'
 import { fail, ErrorType } from '../utils/errors'
 import getDummyMappings from '../utils/getDummyMappings'
 
+declare const __non_webpack_require__: typeof require
+
 type Decentraland = import('./Decentraland').Decentraland
 
 /**
@@ -97,10 +99,19 @@ export class Preview extends EventEmitter {
     }
 
     const dclEcsPath = path.resolve(this.dcl.getWorkingDir(), 'node_modules', 'decentraland-ecs')
+    const proxySetupPath = path.resolve(dclEcsPath, 'src/setupProxy.js')
     const dclApiPath = path.resolve(this.dcl.getWorkingDir(), 'node_modules', 'decentraland-api')
 
     const artifactPath = fs.pathExistsSync(dclEcsPath) ? dclEcsPath : dclApiPath
     const unityPath = path.resolve(dclEcsPath, 'artifacts', 'unity')
+
+    if (fs.existsSync(proxySetupPath)) {
+      try {
+        __non_webpack_require__(proxySetupPath)(this.dcl, this.app, express)
+      } catch (err) {
+        console.log(`${proxySetupPath} found but it couldn't be loaded properly`)
+      }
+    }
 
     if (!fs.pathExistsSync(artifactPath)) {
       fail(


### PR DESCRIPTION
<!--
If there is an issue please refer to it here like `Closes #14` or
`Fixes #1`
-->

# What? <!-- what is this PR? -->
It adds support for a proxy which it's loaded from the ECS module if it exists (specifically from node_modules/decentraland-ecs/src/setupProxy.js)

# Why? <!-- Explain the reason -->
See more https://github.com/decentraland/sdk/issues/12 

