### PR TITLE
feat: import setupExport from decentraland-ecs and call it if exists

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,3 +1,4 @@
+import { MappingsFile } from './../lib/content/types'
 import * as path from 'path'
 import * as fs from 'fs-extra'
 import * as arg from 'arg'
@@ -75,61 +76,77 @@ export async function main(): Promise<number> {
 
   const dclEcsPath = path.resolve(workDir, 'node_modules', 'decentraland-ecs')
   const exportSetupPath = path.resolve(dclEcsPath, 'src/setupExport.js')
-  let externalExport = null
+  let exportDependencies: any = defaultExport
 
   if (fs.existsSync(exportSetupPath)) {
     try {
-      externalExport = __non_webpack_require__(exportSetupPath)
+      const externalExport = __non_webpack_require__(exportSetupPath)
+      exportDependencies = externalExport
     } catch (err) {
       console.log(`${exportSetupPath} found but it couldn't be loaded properly`)
     }
   }
 
-  if (externalExport) {
-    externalExport(exportDir, sceneJson.display.title, mappings)
-  } else {
-    const artifactPath = path.resolve(workDir, 'node_modules', 'decentraland-ecs', 'artifacts')
-
-    // Change HTML title name
-    const content = await fs.readFile(path.resolve(artifactPath, 'export.html'), 'utf-8')
-    const finalContent = content.replace('{{ scene.display.title }}', sceneJson.display.title)
-
-    try {
-      // decentraland-ecs <= 6.6.4
-      await fs.copy(path.resolve(artifactPath, 'unity'), path.resolve(exportDir, 'unity'))
-    } catch {
-      // decentraland-ecs > 6.6.4
-      await fs.copy(
-        path.resolve(artifactPath, 'unity-renderer'),
-        path.resolve(exportDir, 'unity-renderer')
-      )
-    }
-
-    await Promise.all([
-      fs.writeFile(path.resolve(exportDir, 'index.html'), finalContent, 'utf-8'),
-      fs.writeFile(path.resolve(exportDir, 'mappings'), JSON.stringify(mappings), 'utf-8'),
-
-      fs.copy(path.resolve(artifactPath, 'preview.js'), path.resolve(exportDir, 'preview.js')),
-
-      fs.copy(
-        path.resolve(artifactPath, 'default-profile'),
-        path.resolve(exportDir, 'default-profile')
-      ),
-      fs.copy(
-        path.resolve(artifactPath, 'images/decentraland-connect'),
-        path.resolve(exportDir, 'images/decentraland-connect')
-      ),
-      fs.copy(
-        path.resolve(artifactPath, 'images/progress-logo.png'),
-        path.resolve(exportDir, 'images/progress-logo.png')
-      ),
-      fs.copy(
-        path.resolve(artifactPath, 'images/teleport.gif'),
-        path.resolve(exportDir, 'images/teleport.gif')
-      )
-    ])
-  }
+  await exportDependencies({
+    workDir,
+    exportDir,
+    mappings,
+    sceneJson
+  })
 
   spinner.succeed('Export successful.')
   return 0
+}
+
+async function defaultExport({
+  workDir,
+  exportDir,
+  mappings,
+  sceneJson
+}: {
+  workDir: string
+  exportDir: string
+  mappings: MappingsFile
+  sceneJson: any
+}): Promise<void> {
+  const artifactPath = path.resolve(workDir, 'node_modules', 'decentraland-ecs', 'artifacts')
+
+  // Change HTML title name
+  const content = await fs.readFile(path.resolve(artifactPath, 'export.html'), 'utf-8')
+  const finalContent = content.replace('{{ scene.display.title }}', sceneJson.display.title)
+
+  try {
+    // decentraland-ecs <= 6.6.4
+    await fs.copy(path.resolve(artifactPath, 'unity'), path.resolve(exportDir, 'unity'))
+  } catch {
+    // decentraland-ecs > 6.6.4
+    await fs.copy(
+      path.resolve(artifactPath, 'unity-renderer'),
+      path.resolve(exportDir, 'unity-renderer')
+    )
+  }
+
+  await Promise.all([
+    fs.writeFile(path.resolve(exportDir, 'index.html'), finalContent, 'utf-8'),
+    fs.writeFile(path.resolve(exportDir, 'mappings'), JSON.stringify(mappings), 'utf-8'),
+
+    fs.copy(path.resolve(artifactPath, 'preview.js'), path.resolve(exportDir, 'preview.js')),
+
+    fs.copy(
+      path.resolve(artifactPath, 'default-profile'),
+      path.resolve(exportDir, 'default-profile')
+    ),
+    fs.copy(
+      path.resolve(artifactPath, 'images/decentraland-connect'),
+      path.resolve(exportDir, 'images/decentraland-connect')
+    ),
+    fs.copy(
+      path.resolve(artifactPath, 'images/progress-logo.png'),
+      path.resolve(exportDir, 'images/progress-logo.png')
+    ),
+    fs.copy(
+      path.resolve(artifactPath, 'images/teleport.gif'),
+      path.resolve(exportDir, 'images/teleport.gif')
+    )
+  ])
 }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Find a setupExport.js file in the decentraland-ecs package, if it exists, it's called it instead of standard export.

# Why? <!-- Explain the reason -->
In accordance with the new package structure, this allows setting up a custom package export from the ECS. Also, it's maintaining compatibility with the current structure.

# How to test?
1. Build and link the CLI `npm run build && npm link`
2. In a scene project, run `dcl export` and check if it works properly
3. Remove the export generated and create a file in `node_modules/decentraland-ecs/src/setupExport.js` with `module.exports = function (exportDir, sceneTitle, mappings){
    console.log("Hello world");
}`
4. Run again `dcl export` and note only project files were copied without any package 