### PR TITLE
handle peer dependencies unmet as a warning

### DIFF
--- a/src/utils/installedDependencies.ts
+++ b/src/utils/installedDependencies.ts
@@ -26,14 +26,7 @@ async function getDependencyTree(workingDir: string): Promise<Object> {
 
     child.on('close', code => {
       if (code !== 0) {
-        spinner.fail()
-        reject(
-          new Error(
-            `${chalk.bold(
-              `npm ls --json`
-            )} exited with code ${code}. Please try running the command manually`
-          )
-        )
+        spinner.warn(`${chalk.bold(`npm ls --json`)} exited with code ${code}.`)
       }
 
       let dependenciesJson: Object


### PR DESCRIPTION
Closes https://github.com/decentraland/sdk/issues/85

# What? <!-- what is this PR? -->
Log error instead of failing
...

# Why? <!-- Explain the reason -->
When there is an unmet peer dependencies `dcl start` and `dcl install` fail to update package.json with the updated bundleDepencies.
This is beacuse `npm ls --json` exits with a code 1.
...
