### PR TITLE
feat: add asset json modifying when `dcl init` is invoked

### DIFF
--- a/src/lib/Project.ts
+++ b/src/lib/Project.ts
@@ -11,7 +11,8 @@ import {
   getIgnoreFilePath,
   DCLIGNORE_FILE,
   PACKAGE_FILE,
-  getPackageFilePath
+  getPackageFilePath,
+  ASSETJSON_FILE
 } from '../utils/project'
 import { fail, ErrorType } from '../utils/errors'
 import {
@@ -21,6 +22,7 @@ import {
   areConnected,
   Coords
 } from '../utils/coordinateHelpers'
+import uuid from 'uuid'
 
 export interface IFile {
   path: string
@@ -158,6 +160,10 @@ export class Project {
       } else if (file === PACKAGE_FILE) {
         const pkgFile = await readJSON<any>(getPackageFilePath(src))
         await writeJSON(getPackageFilePath(this.workingDir), pkgFile)
+      } else if (file === ASSETJSON_FILE) {
+        const assetJsonFile = await readJSON<any>(path.join(src, file));
+        assetJsonFile.id = uuid.v4();
+        await writeJSON(path.join(this.workingDir, file), assetJsonFile);
       } else {
         await fs.copy(path.join(src, file), path.join(this.workingDir, file))
       }

--- a/src/utils/project.ts
+++ b/src/utils/project.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 export const SCENE_FILE = 'scene.json'
 export const PACKAGE_FILE = 'package.json'
+export const ASSETJSON_FILE = 'asset.json'
 export const DCLIGNORE_FILE = '.dclignore'
 
 /**


### PR DESCRIPTION
<!--
If there is an issue please refer to it here like `Closes #14` or
`Fixes #1`
-->

# What? <!-- what is this PR? -->
Modify the sample portable experience when `dcl init` is invoked

# Why? <!-- Explain the reason -->
To upload the wearable without a uuid in 'id' field it'll fail