### PR TITLE
feat: [deploy] improve files logging

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -141,10 +141,9 @@ export async function main(): Promise<void> {
 
   if (exceedFiles.length) {
     return failWithSpinner(
-      `Cannot deploy files bigger than 50mb. Files: \n\t${
-        exceedFiles.map(file=>`${file.path} ${file.size} bytes`).join(
-        '\n\t'
-      )}`
+      `Cannot deploy files bigger than 50mb. Files: \n\t${exceedFiles
+        .map((file) => `${file.path} ${file.size} bytes`)
+        .join('\n\t')}`
     )
   }
 
@@ -241,18 +240,21 @@ function findPointers(sceneJson: any): string[] {
   return sceneJson.scene.parcels
 }
 
-function getFilesLog(files:IFile[], detailedLog?:boolean){
-  let filesLog:string = `Number of files: ${files.length}\nTotal size: ${files.reduce((acc, file) => acc + file.size, 0)} bytes`;
-  if(detailedLog){
+function getFilesLog(files: IFile[], detailedLog?: boolean) {
+  let filesLog: string = `Number of files: ${
+    files.length
+  }\nTotal size: ${files.reduce((acc, file) => acc + file.size, 0)} bytes`
+  if (detailedLog) {
     filesLog += chalk.dim(
-        `\n${files
-            .sort(sortFilesBySize)
-            .map(file=>`${file.path} ${file.size}`)
-            .join(`\n`)}`)
+      `\n${files
+        .sort(sortFilesBySize)
+        .map((file) => `${file.path} ${file.size}`)
+        .join(`\n`)}`
+    )
   }
   return filesLog
 
-  function sortFilesBySize(a:IFile,b:IFile):number {
+  function sortFilesBySize(a: IFile, b: IFile): number {
     return a.size - b.size
   }
 }

--- a/test/unit/utils/gettingPackageJsonAndVersioning.test.ts
+++ b/test/unit/utils/gettingPackageJsonAndVersioning.test.ts
@@ -20,7 +20,7 @@ test('Unit - getCLIPackageJson() - should have userEngines', async (t) => {
 })
 
 test('Unit - npm and node versions - having installed node and npm should return valid values', async (t) => {
-  const nodeVersion = await getNodeVersion()
+  const nodeVersion = getNodeVersion()
   const npmVersion = await getNpmVersion()
 
   t.true(typeof nodeVersion === 'string')


### PR DESCRIPTION
# What? <!-- what is this PR? -->
In `dcl deploy` command:
+ Adds a log with number of files and total size
+ Add option `--log-files` to log detailed list of all files and size ordered by size
+ fix: [deploy] exceeded size files log
+ fix warning on tests about unnecessary await

# Why? <!-- Explain the reason -->
+ Fixes a bug on exceeded file size error message
+ Can help giving support to SDK users
+ To check unused files being upload
+ To check bigger files being uploaded and analysis for optimization
+ To keep control of the number of files being uploaded and the total size
+ To check empty files (reported to be problematic)

