### PR TITLE
feat: upgrade linker dapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp
 dist
 .DS_Store
 test-*
+decentraland-*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.14.0",
+  "version": "3.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@dcl/ecs-scene-utils": "^1.7.5",
-        "@dcl/linker-dapp": "^0.3.1-3060563892.commit-56b624a",
+        "@dcl/linker-dapp": "^0.4.0",
         "@dcl/mini-comms": "1.0.0",
         "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3130782694.commit-94713ab.tgz",
         "@dcl/schemas": "^5.14.0",
@@ -167,9 +167,9 @@
       "peer": true
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.3.1-3060563892.commit-56b624a",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.3.1-3060563892.commit-56b624a.tgz",
-      "integrity": "sha512-VA37xZoyz6ANbVFxj7NPSrqNlHHbrqBI5M+jjSUOvbpk5t2FZQq8J84ha7UKq7CKAly5Nnvmysjz3UG55XmmkQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.4.0.tgz",
+      "integrity": "sha512-yLipflkauKxEdf9FNqM3yYWQaGG8t3A4eb7DXhae1ZM29qQXv0dQvio5tKFK1fxgGsj9v+CqLrvnDF2fwvmeoA=="
     },
     "node_modules/@dcl/mini-comms": {
       "version": "1.0.0",
@@ -7714,9 +7714,9 @@
       "peer": true
     },
     "@dcl/linker-dapp": {
-      "version": "0.3.1-3060563892.commit-56b624a",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.3.1-3060563892.commit-56b624a.tgz",
-      "integrity": "sha512-VA37xZoyz6ANbVFxj7NPSrqNlHHbrqBI5M+jjSUOvbpk5t2FZQq8J84ha7UKq7CKAly5Nnvmysjz3UG55XmmkQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.4.0.tgz",
+      "integrity": "sha512-yLipflkauKxEdf9FNqM3yYWQaGG8t3A4eb7DXhae1ZM29qQXv0dQvio5tKFK1fxgGsj9v+CqLrvnDF2fwvmeoA=="
     },
     "@dcl/mini-comms": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.14.0",
+  "version": "3.13.0",
   "description": "Decentraland CLI developer tool.",
   "bin": {
     "dcl": "dist/index.js"
@@ -65,7 +65,7 @@
   "dependencies": {
     "@dcl/crypto": "^3.0.1",
     "@dcl/ecs-scene-utils": "^1.7.5",
-    "@dcl/linker-dapp": "^0.3.1-3060563892.commit-56b624a",
+    "@dcl/linker-dapp": "^0.4.0",
     "@dcl/mini-comms": "1.0.0",
     "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3130782694.commit-94713ab.tgz",
     "@dcl/schemas": "^5.14.0",


### PR DESCRIPTION
Upgrade `@dcl/linkder-dapp` to get support for WalletConnect, WalletLink and Fortmatic.