### PR TITLE
feat: catalystUrl from .dclinfo

### DIFF
--- a/src/lib/controllers/ecs6-endpoints.ts
+++ b/src/lib/controllers/ecs6-endpoints.ts
@@ -11,6 +11,10 @@ import { fetchEntityByPointer } from '../../utils/catalystPointers'
 import { smartWearableNameToId } from '../../project/projectInfo'
 import { getConfig } from '../../config'
 
+function getCatalystUrl(): URL {
+  return new URL(getConfig().catalystUrl ?? 'https://peer.decentraland.org')
+}
+
 export function setupEcs6Endpoints(
   components: PreviewComponents,
   router: Router<PreviewComponents>
@@ -62,9 +66,7 @@ export function setupEcs6Endpoints(
       }).map((wearable) => wearable.id)
 
       if (previewWearables.length === 1) {
-        const catalystUrl = new URL(
-          getConfig().catalystUrl ?? 'https://peer.decentraland.org'
-        )
+        const catalystUrl = getCatalystUrl()
 
         const u = new URL(ctx.url.toString())
         u.host = catalystUrl.host
@@ -104,9 +106,7 @@ export function setupEcs6Endpoints(
   })
 
   router.all('/lambdas/:path+', async (ctx) => {
-    const catalystUrl = new URL(
-      getConfig().catalystUrl ?? 'https://peer.decentraland.org'
-    )
+    const catalystUrl = getCatalystUrl()
     const u = new URL(ctx.url.toString())
     u.host = catalystUrl.host
     u.protocol = catalystUrl.protocol
@@ -128,11 +128,10 @@ export function setupEcs6Endpoints(
   })
 
   router.post('/content/entities', async (ctx) => {
-    const catalystUrl =
-      getConfig().catalystUrl ?? 'https://peer.decentraland.org'
+    const catalystUrl = getCatalystUrl()
     const headers = new Headers()
     console.log(ctx.request.headers)
-    const res = await fetch(`${catalystUrl}/content/entities`, {
+    const res = await fetch(`${catalystUrl.toString()}/content/entities`, {
       method: 'post',
       headers,
       body: ctx.request.body
@@ -220,10 +219,9 @@ function serveFolders(
       baseFolders,
       pointers: Array.from(requestedPointers)
     })
-    const catalystUrl =
-      getConfig().catalystUrl ?? 'https://peer.decentraland.org'
+    const catalystUrl = getCatalystUrl()
     const remote = fetchEntityByPointer(
-      catalystUrl,
+      catalystUrl.toString(),
       pointers.filter(($: string) => !$.match(/-?\d+,-?\d+/))
     )
 

--- a/src/lib/controllers/ecs6-endpoints.ts
+++ b/src/lib/controllers/ecs6-endpoints.ts
@@ -9,6 +9,7 @@ import ignore from 'ignore'
 import fetch, { Headers } from 'node-fetch'
 import { fetchEntityByPointer } from '../../utils/catalystPointers'
 import { smartWearableNameToId } from '../../project/projectInfo'
+import { getConfig } from '../../config'
 
 export function setupEcs6Endpoints(
   components: PreviewComponents,
@@ -61,9 +62,13 @@ export function setupEcs6Endpoints(
       }).map((wearable) => wearable.id)
 
       if (previewWearables.length === 1) {
+        const catalystUrl = new URL(
+          getConfig().catalystUrl ?? 'https://peer.decentraland.org'
+        )
+
         const u = new URL(ctx.url.toString())
-        u.host = 'peer.decentraland.org'
-        u.protocol = 'https:'
+        u.host = catalystUrl.host
+        u.protocol = catalystUrl.protocol
         u.port = ''
         const req = await fetch(u.toString(), {
           headers: {
@@ -99,9 +104,12 @@ export function setupEcs6Endpoints(
   })
 
   router.all('/lambdas/:path+', async (ctx) => {
+    const catalystUrl = new URL(
+      getConfig().catalystUrl ?? 'https://peer.decentraland.org'
+    )
     const u = new URL(ctx.url.toString())
-    u.host = 'peer.decentraland.org'
-    u.protocol = 'https:'
+    u.host = catalystUrl.host
+    u.protocol = catalystUrl.protocol
     u.port = ''
     const req = await fetch(u.toString(), {
       headers: {
@@ -120,9 +128,11 @@ export function setupEcs6Endpoints(
   })
 
   router.post('/content/entities', async (ctx) => {
+    const catalystUrl =
+      getConfig().catalystUrl ?? 'https://peer.decentraland.org'
     const headers = new Headers()
     console.log(ctx.request.headers)
-    const res = await fetch('https://peer.decentraland.org/content/entities', {
+    const res = await fetch(`${catalystUrl}/content/entities`, {
       method: 'post',
       headers,
       body: ctx.request.body
@@ -210,9 +220,10 @@ function serveFolders(
       baseFolders,
       pointers: Array.from(requestedPointers)
     })
-
+    const catalystUrl =
+      getConfig().catalystUrl ?? 'https://peer.decentraland.org'
     const remote = fetchEntityByPointer(
-      'https://peer.decentraland.org',
+      catalystUrl,
       pointers.filter(($: string) => !$.match(/-?\d+,-?\d+/))
     )
 

--- a/src/lib/controllers/ecs6-endpoints.ts
+++ b/src/lib/controllers/ecs6-endpoints.ts
@@ -69,7 +69,7 @@ export function setupEcs6Endpoints(
         const u = new URL(ctx.url.toString())
         u.host = catalystUrl.host
         u.protocol = catalystUrl.protocol
-        u.port = ''
+        u.port = catalystUrl.port
         const req = await fetch(u.toString(), {
           headers: {
             connection: 'close'
@@ -110,7 +110,7 @@ export function setupEcs6Endpoints(
     const u = new URL(ctx.url.toString())
     u.host = catalystUrl.host
     u.protocol = catalystUrl.protocol
-    u.port = ''
+    u.port = catalystUrl.port
     const req = await fetch(u.toString(), {
       headers: {
         connection: 'close'


### PR DESCRIPTION
# Why? <!-- Explain the reason -->
To don't have a fixed catalyst on ECS6. Now you can configure your preferent catalyst.