### PR TITLE
chore: upgrade linker-dapp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.13.0",
+  "version": "3.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@dcl/ecs-scene-utils": "^1.7.5",
-        "@dcl/linker-dapp": "^0.4.0",
+        "@dcl/linker-dapp": "^0.6.0",
         "@dcl/mini-comms": "1.0.0",
         "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3130782694.commit-94713ab.tgz",
         "@dcl/schemas": "^5.14.0",
@@ -167,9 +167,9 @@
       "peer": true
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.4.0.tgz",
-      "integrity": "sha512-yLipflkauKxEdf9FNqM3yYWQaGG8t3A4eb7DXhae1ZM29qQXv0dQvio5tKFK1fxgGsj9v+CqLrvnDF2fwvmeoA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.6.0.tgz",
+      "integrity": "sha512-HAxvQLOPM5g4+rnivD2LlgCVVJdSml4fOWoxNwp5XOayB6HTd/lRUedWOXgxbzo5L5iLrR7obMirnzvnHeFjlA=="
     },
     "node_modules/@dcl/mini-comms": {
       "version": "1.0.0",
@@ -7714,9 +7714,9 @@
       "peer": true
     },
     "@dcl/linker-dapp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.4.0.tgz",
-      "integrity": "sha512-yLipflkauKxEdf9FNqM3yYWQaGG8t3A4eb7DXhae1ZM29qQXv0dQvio5tKFK1fxgGsj9v+CqLrvnDF2fwvmeoA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.6.0.tgz",
+      "integrity": "sha512-HAxvQLOPM5g4+rnivD2LlgCVVJdSml4fOWoxNwp5XOayB6HTd/lRUedWOXgxbzo5L5iLrR7obMirnzvnHeFjlA=="
     },
     "@dcl/mini-comms": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland",
-  "version": "3.13.0",
+  "version": "3.15.0",
   "description": "Decentraland CLI developer tool.",
   "bin": {
     "dcl": "dist/index.js"
@@ -65,7 +65,7 @@
   "dependencies": {
     "@dcl/crypto": "^3.0.1",
     "@dcl/ecs-scene-utils": "^1.7.5",
-    "@dcl/linker-dapp": "^0.4.0",
+    "@dcl/linker-dapp": "^0.6.0",
     "@dcl/mini-comms": "1.0.0",
     "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3130782694.commit-94713ab.tgz",
     "@dcl/schemas": "^5.14.0",


### PR DESCRIPTION
This PR upgrades the linker-dapp to the version `v0.6.0` which includes:

-  The fix for the issue were rented land could not be deployed onto
- The NPS survey after a successful deployment (see https://github.com/decentraland/sdk/issues/543)