### PR TITLE
remove latest condition for sdk7

### DIFF
--- a/src/utils/moduleHelpers.ts
+++ b/src/utils/moduleHelpers.ts
@@ -103,10 +103,6 @@ export async function getOutdatedEcs(workingDir: string): Promise<
     }
   | undefined
 > {
-  const decentralandEcs7Version = await getInstalledVersion(
-    workingDir,
-    '@dcl/sdk'
-  )
   const decentralandEcs6Version = await getInstalledVersion(
     workingDir,
     'decentraland-ecs'
@@ -121,17 +117,7 @@ export async function getOutdatedEcs(workingDir: string): Promise<
         latestVersion
       }
     }
-  } else if (decentralandEcs7Version) {
-    const latestVersion = await getLatestVersion('@dcl/sdk')
-    if (latestVersion && semver.lt(decentralandEcs7Version, latestVersion)) {
-      return {
-        package: '@dcl/sdk',
-        installedVersion: decentralandEcs7Version,
-        latestVersion
-      }
-    }
   }
-
   return undefined
 }
 


### PR DESCRIPTION
For the SDK7 we dont use anymore the CLI. So if you want to use an outdated version like 7.0.5 this will always fail.