### PR TITLE
fix network when ci param is set

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ export type DCLInfo = {
   segmentKey?: string
 }
 
-let networkFlag: string
+let networkFlag: string = 'mainnet'
 let config: DCLInfo
 
 /**


### PR DESCRIPTION
<!--
If there is an issue please refer to it here like `Closes #14` or
`Fixes #1`
-->

# What? <!-- what is this PR? -->
use mainnet as default network

...

# Why? <!-- Explain the reason -->
When you use the ci param in the start command `dcl start --ci` and you try to use ENABLE_WEB3 to use your profile, then the fetch was being done to the .zone because the network was undefined.
https://github.com/decentraland/cli/blob/main/src/main.ts#L80-L94

...
